### PR TITLE
add 'search' param to vlan endpoint

### DIFF
--- a/pkg/vlan/api.go
+++ b/pkg/vlan/api.go
@@ -8,7 +8,7 @@ import (
 
 // API contains methods for VLAN control.
 type API interface {
-	List(ctx context.Context, page, limit int) ([]Summary, error)
+	List(ctx context.Context, page, limit int, search string) ([]Summary, error)
 	Get(ctx context.Context, identifier string) (Info, error)
 	Create(ctx context.Context, createDefinition CreateDefinition) (Summary, error)
 	Delete(ctx context.Context, identifier string) error

--- a/pkg/vlan/vlan.go
+++ b/pkg/vlan/vlan.go
@@ -61,11 +61,11 @@ type listResponse struct {
 	} `json:"data"`
 }
 
-func (a api) List(ctx context.Context, page, limit int) ([]Summary, error) {
+func (a api) List(ctx context.Context, page, limit int, search string) ([]Summary, error) {
 	url := fmt.Sprintf(
-		"%s%s?page=%v&limit=%v",
+		"%s%s?page=%d&limit=%d&search=%s",
 		a.client.BaseURL(),
-		pathPrefix, page, limit,
+		pathPrefix, page, limit, search,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/tests/vlan_test.go
+++ b/tests/vlan_test.go
@@ -26,7 +26,7 @@ var _ = Describe("VLAN API endpoint tests", func() {
 		It("Should list all available VLANs", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
-			_, err := vlan.NewAPI(cli).List(ctx, 1, 1000)
+			_, err := vlan.NewAPI(cli).List(ctx, 1, 1000, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

### Description
add 'search' param to vlan endpoint
<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
