### PR TITLE
add list cpu performance types api

### DIFF
--- a/pkg/vsphere/provisioning/cpuperformancetypes/api.go
+++ b/pkg/vsphere/provisioning/cpuperformancetypes/api.go
@@ -1,0 +1,21 @@
+package cpuperformancetype
+
+import (
+	"context"
+
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+)
+
+// API contains methods for template querying.
+type API interface {
+	List(ctx context.Context) ([]CPUPerformanceType, error)
+}
+
+type api struct {
+	client client.Client
+}
+
+// NewAPI creates a new template API instance with the given client.
+func NewAPI(c client.Client) API {
+	return api{c}
+}

--- a/pkg/vsphere/provisioning/cpuperformancetypes/cpu_performance_types.go
+++ b/pkg/vsphere/provisioning/cpuperformancetypes/cpu_performance_types.go
@@ -1,0 +1,49 @@
+// Package templates implements API functions residing under /provisioning/cpuperformancetype.
+// This path contains methods for querying available VM templates.
+package cpuperformancetype
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// CPUPerformanceType
+type CPUPerformanceType struct {
+	ID             string  `json:"id"`
+	Prioritization string  `json:"prioritization"`
+	Limit          float64 `json:"limit"`
+	Unit           string  `json:"unit"`
+}
+
+const (
+	// TemplateTypeTemplates are templates that already contain a distribution.
+	TemplateTypeTemplates string = "templates"
+	// TemplateTypeFromScratch are templates that need to have distribution added to work.
+	TemplateTypeFromScratch string = "from_scratch"
+	pathPrefix              string = "/api/vsphere/v1/provisioning/cpu_performance_type.json"
+)
+
+func (a api) List(ctx context.Context) ([]CPUPerformanceType, error) {
+	url := fmt.Sprintf("%s%s", a.client.BaseURL(), pathPrefix)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("could not create cpu performance type list request: %w", err)
+	}
+
+	httpResponse, err := a.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not execute cpu performance type list request: %w", err)
+	}
+	var responsePayload []CPUPerformanceType
+	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
+	_ = httpResponse.Body.Close()
+
+	if err != nil {
+		return nil, fmt.Errorf("could not decode cpu performance type list response: %w", err)
+	}
+
+	return responsePayload, err
+}

--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -5,11 +5,13 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"fmt"
-	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/disktype"
 	"log"
 	"math/rand"
 	"strings"
 	"time"
+
+	cpuperformancetype "github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/cpuperformancetypes"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/disktype"
 
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/anexia-it/go-anxcloud/pkg/ipam/address"
@@ -122,6 +124,17 @@ var _ = Describe("Vsphere API endpoint tests", func() {
 				defer cancel()
 
 				_, err := disktype.NewAPI(cli).List(ctx, locationID, 1, 1000)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+		})
+
+		Context("CPU Performance Type endpoint", func() {
+
+			It("Should list all cpu performance types", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
+				defer cancel()
+				_, err := cpuperformancetype.NewAPI(cli).List(ctx)
 				Expect(err).NotTo(HaveOccurred())
 			})
 


### PR DESCRIPTION
### Description

add list cpu performance types api

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
add list cpu performance types api
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
