### PR TITLE
add option to pass base64 encrypted script

### DIFF
--- a/pkg/vsphere/provisioning/vm/api.go
+++ b/pkg/vsphere/provisioning/vm/api.go
@@ -10,7 +10,7 @@ import (
 type API interface {
 	NewDefinition(location, templateType, templateID, hostname string, cpus, memory, disk int, network []Network) Definition
 	Deprovision(ctx context.Context, identifier string, delayed bool) error
-	Provision(ctx context.Context, definition Definition) (ProvisioningResponse, error)
+	Provision(ctx context.Context, definition Definition, base64Encoding bool) (ProvisioningResponse, error)
 	Update(ctx context.Context, vmID string, change Change) (ProvisioningResponse, error)
 }
 

--- a/pkg/vsphere/provisioning/vm/provision.go
+++ b/pkg/vsphere/provisioning/vm/provision.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,8 +29,13 @@ var ErrProvisioning = errors.New("ProvisioningResponse contains errors")
 //
 // If the API call returns errors, they are raised as ErrProvisioning.
 // The returned ProvisioningResponse is still valid in this case.
-func (a api) Provision(ctx context.Context, definition Definition) (ProvisioningResponse, error) {
+func (a api) Provision(ctx context.Context, definition Definition, scriptBase64Encoded bool) (ProvisioningResponse, error) {
 	buf := bytes.Buffer{}
+
+	if definition.Script != "" && scriptBase64Encoded {
+		definition.Script = base64.StdEncoding.EncodeToString([]byte(definition.Script))
+	}
+
 	if err := json.NewEncoder(&buf).Encode(&definition); err != nil {
 		panic(fmt.Sprintf("could not encode definition: %v", err))
 	}

--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -68,7 +68,8 @@ var _ = Describe("Vsphere API endpoint tests", func() {
 				definition.SSH = randomPublicSSHKey()
 
 				By("Creating a new VM")
-				provisionResponse, err := vm.NewAPI(cli).Provision(ctx, definition)
+				base64Encoding := true
+				provisionResponse, err := vm.NewAPI(cli).Provision(ctx, definition, base64Encoding)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Waiting for the VM to be ready")


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

### Description
add option to pass base64 encrypted script

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add option to encrypt script by base64
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
