### PR TITLE
add missing fields for network prefix

### DIFF
--- a/pkg/ipam/prefix/prefix.go
+++ b/pkg/ipam/prefix/prefix.go
@@ -69,6 +69,8 @@ type Info struct {
 	Role                string     `json:"role_text"`
 	Status              string     `json:"status"`
 	Locations           []Location `json:"locations"`
+	VLANID              string     `json:"vlan_id"`
+	RouterRedundancy    bool       `json:"router_redundancy"`
 }
 
 // Update contains fields to change on a prefix.


### PR DESCRIPTION
Signed-off-by: Marcin Franczyk <marcin0franczyk@gmail.com>

### Description
add missing fields for network prefix

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
