### PR TITLE
5xx handling

### DIFF
--- a/pkg/core/location/location.go
+++ b/pkg/core/location/location.go
@@ -47,6 +47,9 @@ func (a api) List(ctx context.Context, page, limit int, search string) ([]Locati
 	if err != nil {
 		return nil, fmt.Errorf("could not execute location list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute location list request, got response %s", httpResponse.Status)
+	}
 
 	var responsePayload listResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)

--- a/pkg/core/resource/resource.go
+++ b/pkg/core/resource/resource.go
@@ -51,6 +51,9 @@ func (a api) List(ctx context.Context, page, limit int) ([]Summary, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not execute resource list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute resource list request, got response %s", httpResponse.Status)
+	}
 
 	var responsePayload listResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
@@ -79,6 +82,10 @@ func (a api) Get(ctx context.Context, id string) (Info, error) {
 	if err != nil {
 		return Info{}, fmt.Errorf("could not execute resource get request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Info{}, fmt.Errorf("could not execute resource get request, got response %s", httpResponse.Status)
+	}
+
 	var info Info
 	err = json.NewDecoder(httpResponse.Body).Decode(&info)
 	_ = httpResponse.Body.Close()
@@ -105,6 +112,10 @@ func (a api) AttachTag(ctx context.Context, resourceID, tagName string) ([]Summa
 	if err != nil {
 		return nil, fmt.Errorf("could not execute attach tag request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute attach tag request, got response %s", httpResponse.Status)
+	}
+
 	var summary []Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()
@@ -130,6 +141,9 @@ func (a api) DetachTag(ctx context.Context, resourceID, tagName string) error {
 	httpResponse, err := a.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("could not execute tag delete request: %w", err)
+	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute tag delete request, got response %s", httpResponse.Status)
 	}
 
 	return httpResponse.Body.Close()

--- a/pkg/core/service/service.go
+++ b/pkg/core/service/service.go
@@ -41,6 +41,9 @@ func (a api) List(ctx context.Context, page, limit int) ([]Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not execute service list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute service list request, got response %s", httpResponse.Status)
+	}
 
 	var responsePayload listResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)

--- a/pkg/core/tags/tags.go
+++ b/pkg/core/tags/tags.go
@@ -77,6 +77,9 @@ func (a api) List(ctx context.Context, page, limit int, query, serviceIdentifier
 	if err != nil {
 		return nil, fmt.Errorf("could not execute tags list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute tags list request, got response %s", httpResponse.Status)
+	}
 
 	var responsePayload listResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
@@ -105,6 +108,10 @@ func (a api) Get(ctx context.Context, identifier string) (Info, error) {
 	if err != nil {
 		return Info{}, fmt.Errorf("could not execute tags get request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Info{}, fmt.Errorf("could not execute tags get request, got response %s", httpResponse.Status)
+	}
+
 	var info Info
 	err = json.NewDecoder(httpResponse.Body).Decode(&info)
 	_ = httpResponse.Body.Close()
@@ -136,6 +143,10 @@ func (a api) Create(ctx context.Context, create Create) (Summary, error) {
 	if err != nil {
 		return Summary{}, fmt.Errorf("could not execute tag post request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Summary{}, fmt.Errorf("could not execute tag post request, got response %s", httpResponse.Status)
+	}
+
 	var summary Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()
@@ -161,6 +172,9 @@ func (a api) Delete(ctx context.Context, tagID, serviceID string) error {
 	httpResponse, err := a.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("could not execute tag delete request: %w", err)
+	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute tag delete request, got response %s", httpResponse.Status)
 	}
 
 	return httpResponse.Body.Close()

--- a/pkg/ipam/address/address.go
+++ b/pkg/ipam/address/address.go
@@ -106,6 +106,10 @@ func (a api) List(ctx context.Context, page, limit int, search string) ([]Summar
 	if err != nil {
 		return nil, fmt.Errorf("could not execute address list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute address list request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload listResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()
@@ -134,6 +138,10 @@ func (a api) Get(ctx context.Context, id string) (Address, error) {
 	if err != nil {
 		return Address{}, fmt.Errorf("could not execute address get request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Address{}, fmt.Errorf("could not execute address get request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload Address
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()
@@ -162,6 +170,9 @@ func (a api) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("could not execute address delete request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute address delete request, got response %s", httpResponse.Status)
+	}
 
 	return httpResponse.Body.Close()
 }
@@ -187,6 +198,10 @@ func (a api) Create(ctx context.Context, create Create) (Summary, error) {
 	if err != nil {
 		return Summary{}, fmt.Errorf("could not execute vlan post request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Summary{}, fmt.Errorf("could not execute vlan post request, got response %s", httpResponse.Status)
+	}
+
 	var summary Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()
@@ -218,6 +233,10 @@ func (a api) Update(ctx context.Context, id string, update Update) (Summary, err
 	if err != nil {
 		return Summary{}, fmt.Errorf("could not execute vlan update request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Summary{}, fmt.Errorf("could not execute vlan update request, got response %s", httpResponse.Status)
+	}
+
 	var summary Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()
@@ -249,6 +268,10 @@ func (a api) ReserveRandom(ctx context.Context, reserve ReserveRandom) (ReserveR
 	if err != nil {
 		return ReserveRandomSummary{}, fmt.Errorf("could not execute IP address reserve random post request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return ReserveRandomSummary{}, fmt.Errorf("could not execute IP address reserve random post request, got response %s", httpResponse.Status)
+	}
+
 	var summary ReserveRandomSummary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()

--- a/pkg/ipam/address/address.go
+++ b/pkg/ipam/address/address.go
@@ -21,7 +21,7 @@ type Address struct {
 	Name                string `json:"name"`
 	DescriptionCustomer string `json:"description_customer"`
 	DescriptionInternal string `json:"description_internal"`
-	Role                string `json:"role"`
+	Role                string `json:"role_text"`
 	Version             int    `json:"version"`
 	Status              string `json:"status"`
 	VLANID              string `json:"vlan"`

--- a/pkg/ipam/prefix/prefix.go
+++ b/pkg/ipam/prefix/prefix.go
@@ -108,6 +108,9 @@ func (a api) List(ctx context.Context, page, limit int) ([]Summary, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not execute vlan list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute vlan list request, got response %s", httpResponse.Status)
+	}
 
 	var responsePayload listResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
@@ -136,6 +139,10 @@ func (a api) Get(ctx context.Context, id string) (Info, error) {
 	if err != nil {
 		return Info{}, fmt.Errorf("could not execute vlan get request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Info{}, fmt.Errorf("could not execute vlan get request, got response %s", httpResponse.Status)
+	}
+
 	var info Info
 	err = json.NewDecoder(httpResponse.Body).Decode(&info)
 	_ = httpResponse.Body.Close()
@@ -162,6 +169,9 @@ func (a api) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return fmt.Errorf("could not execute vlan delete request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute vlan delete request, got response %s", httpResponse.Status)
+	}
 
 	return httpResponse.Body.Close()
 }
@@ -187,6 +197,10 @@ func (a api) Create(ctx context.Context, create Create) (Summary, error) {
 	if err != nil {
 		return Summary{}, fmt.Errorf("could not execute vlan post request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Summary{}, fmt.Errorf("could not execute vlan post request, got response %s", httpResponse.Status)
+	}
+
 	var summary Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()
@@ -218,6 +232,10 @@ func (a api) Update(ctx context.Context, id string, update Update) (Summary, err
 	if err != nil {
 		return Summary{}, fmt.Errorf("could not execute vlan update request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Summary{}, fmt.Errorf("could not execute vlan update request, got response %s", httpResponse.Status)
+	}
+
 	var summary Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()

--- a/pkg/test/echo/echo.go
+++ b/pkg/test/echo/echo.go
@@ -43,6 +43,9 @@ func (a api) Echo(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute echo request, got response %s", httpResponse.Status)
+	}
 
 	var responsePayload string
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)

--- a/pkg/vlan/vlan.go
+++ b/pkg/vlan/vlan.go
@@ -78,6 +78,9 @@ func (a api) List(ctx context.Context, page, limit int, search string) ([]Summar
 	if err != nil {
 		return nil, fmt.Errorf("could not execute vlan list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute vlan list request, got response %s", httpResponse.Status)
+	}
 
 	var responsePayload listResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
@@ -106,6 +109,10 @@ func (a api) Get(ctx context.Context, identifier string) (Info, error) {
 	if err != nil {
 		return Info{}, fmt.Errorf("could not execute vlan get request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Info{}, fmt.Errorf("could not execute vlan get request, got response %s", httpResponse.Status)
+	}
+
 	var info Info
 	err = json.NewDecoder(httpResponse.Body).Decode(&info)
 	_ = httpResponse.Body.Close()
@@ -137,6 +144,10 @@ func (a api) Create(ctx context.Context, createDefinition CreateDefinition) (Sum
 	if err != nil {
 		return Summary{}, fmt.Errorf("could not execute vlan post request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Summary{}, fmt.Errorf("could not execute vlan post request, got response %s", httpResponse.Status)
+	}
+
 	var summary Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()
@@ -168,6 +179,10 @@ func (a api) Update(ctx context.Context, identifier string, updateDefinition Upd
 	if err != nil {
 		return fmt.Errorf("could not execute vlan update request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute vlan update request, got response %s", httpResponse.Status)
+	}
+
 	var summary Summary
 	err = json.NewDecoder(httpResponse.Body).Decode(&summary)
 	_ = httpResponse.Body.Close()
@@ -193,6 +208,9 @@ func (a api) Delete(ctx context.Context, identifier string) error {
 	httpResponse, err := a.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("could not execute vlan delete request: %w", err)
+	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute vlan delete request, got response %s", httpResponse.Status)
 	}
 
 	return httpResponse.Body.Close()

--- a/pkg/vlan/vlan.go
+++ b/pkg/vlan/vlan.go
@@ -40,6 +40,7 @@ type Info struct {
 	InternalDescription string `json:"description_internal"`
 	Role                string `json:"role_text"`
 	Status              string `json:"status"`
+	VMProvisioning      bool   `json:"vm_provisioning,omitempty"`
 	Locations           []Location
 }
 

--- a/pkg/vsphere/info/info.go
+++ b/pkg/vsphere/info/info.go
@@ -19,9 +19,12 @@ type Info struct {
 	CustomName       string     `json:"custom_name"`
 	Identifier       string     `json:"identifier"`
 	GuestOS          string     `json:"guest_os"`
+	LocationID       string     `json:"location_id"`
 	LocationCode     string     `json:"location_code"`
 	LocationCountry  string     `json:"location_country"`
 	LocationName     string     `json:"location_name"`
+	TemplateID       string     `json:"template_id"`
+	TemplateType     string     `json:"template_type"`
 	Status           string     `json:"status"`
 	VersionTools     string     `json:"version_tools"`
 	GuestToolsStatus string     `json:"guest_tools_status"`

--- a/pkg/vsphere/info/info.go
+++ b/pkg/vsphere/info/info.go
@@ -79,6 +79,10 @@ func (a api) Get(ctx context.Context, identifier string) (Info, error) {
 	if err != nil {
 		return Info{}, fmt.Errorf("could not execute VM info request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Info{}, fmt.Errorf("could not execute VM info request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload Info
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/cpuperformancetypes/cpu_performance_types.go
+++ b/pkg/vsphere/provisioning/cpuperformancetypes/cpu_performance_types.go
@@ -37,6 +37,10 @@ func (a api) List(ctx context.Context) ([]CPUPerformanceType, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not execute cpu performance type list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute cpu performance type list request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload []CPUPerformanceType
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/disktype/disktype.go
+++ b/pkg/vsphere/provisioning/disktype/disktype.go
@@ -36,6 +36,10 @@ func (a api) List(ctx context.Context, locationID string, page, limit int) ([]Di
 	if err != nil {
 		return nil, fmt.Errorf("could not execute disk type list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute disk type list request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload []DiskType
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/ips/ips.go
+++ b/pkg/vsphere/provisioning/ips/ips.go
@@ -42,6 +42,9 @@ func (a api) GetFree(ctx context.Context, location, vlan string) ([]IP, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get ips: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute ip get request, got response %s", httpResponse.Status)
+	}
 
 	responsePayload := response{}
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)

--- a/pkg/vsphere/provisioning/location/list.go
+++ b/pkg/vsphere/provisioning/location/list.go
@@ -59,6 +59,10 @@ func (a api) List(ctx context.Context, page, limit int, locationCode, organizati
 	if err != nil {
 		return nil, fmt.Errorf("could not execute location list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute location list request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload response
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/nictype/nic_type.go
+++ b/pkg/vsphere/provisioning/nictype/nic_type.go
@@ -30,6 +30,10 @@ func (a api) List(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not execute nic types list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute nic types list request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload []string
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/progress/progress.go
+++ b/pkg/vsphere/provisioning/progress/progress.go
@@ -61,6 +61,10 @@ func (a api) Get(ctx context.Context, identifier string) (Progress, error) {
 	if err != nil {
 		return Progress{}, fmt.Errorf("could not execute progress get request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return Progress{}, fmt.Errorf("could not execute progress get request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload Progress
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/templates/templates.go
+++ b/pkg/vsphere/provisioning/templates/templates.go
@@ -103,6 +103,10 @@ func (a api) List(ctx context.Context, locationID string, templateType string, p
 	if err != nil {
 		return nil, fmt.Errorf("could not execute template list request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute template list request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload []Template
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/vm/api.go
+++ b/pkg/vsphere/provisioning/vm/api.go
@@ -10,7 +10,7 @@ import (
 type API interface {
 	NewDefinition(location, templateType, templateID, hostname string, cpus, memory, disk int, network []Network) Definition
 	Deprovision(ctx context.Context, identifier string, delayed bool) error
-	Provision(ctx context.Context, definition Definition) (ProvisioningResponse, error)
+	Provision(ctx context.Context, definition Definition, base64Encoding bool) (ProvisioningResponse, error)
 	Update(ctx context.Context, vmID string, change Change) (ProvisioningResponse, error)
 }
 

--- a/pkg/vsphere/provisioning/vm/deprovision.go
+++ b/pkg/vsphere/provisioning/vm/deprovision.go
@@ -33,6 +33,10 @@ func (a api) Deprovision(ctx context.Context, identifier string, delayed bool) e
 	if err != nil {
 		return fmt.Errorf("could not execute VM deprovisioning request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return fmt.Errorf("could not execute VM deprovisioning request, got response %s", httpResponse.Status)
+	}
+
 	_ = httpResponse.Body.Close()
 
 	if err != nil {

--- a/pkg/vsphere/provisioning/vm/provision.go
+++ b/pkg/vsphere/provisioning/vm/provision.go
@@ -58,6 +58,10 @@ func (a api) Provision(ctx context.Context, definition Definition, scriptBase64E
 	if err != nil {
 		return ProvisioningResponse{}, fmt.Errorf("could not execute VM provisioning request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return ProvisioningResponse{}, fmt.Errorf("could not execute VM provisioning request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload ProvisioningResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/provisioning/vm/provision.go
+++ b/pkg/vsphere/provisioning/vm/provision.go
@@ -3,6 +3,7 @@ package vm
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,8 +29,13 @@ var ErrProvisioning = errors.New("ProvisioningResponse contains errors")
 //
 // If the API call returns errors, they are raised as ErrProvisioning.
 // The returned ProvisioningResponse is still valid in this case.
-func (a api) Provision(ctx context.Context, definition Definition) (ProvisioningResponse, error) {
+func (a api) Provision(ctx context.Context, definition Definition, scriptBase64Encoded bool) (ProvisioningResponse, error) {
 	buf := bytes.Buffer{}
+
+	if definition.Script != "" && scriptBase64Encoded {
+		definition.Script = base64.StdEncoding.EncodeToString([]byte(definition.Script))
+	}
+
 	if err := json.NewEncoder(&buf).Encode(&definition); err != nil {
 		panic(fmt.Sprintf("could not encode definition: %v", err))
 	}

--- a/pkg/vsphere/provisioning/vm/update.go
+++ b/pkg/vsphere/provisioning/vm/update.go
@@ -30,6 +30,10 @@ func (a api) Update(ctx context.Context, identifier string, change Change) (Prov
 	if err != nil {
 		return ProvisioningResponse{}, fmt.Errorf("could not execute VM update request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return ProvisioningResponse{}, fmt.Errorf("could not execute VM update request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload ProvisioningResponse
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/pkg/vsphere/search/name.go
+++ b/pkg/vsphere/search/name.go
@@ -55,6 +55,10 @@ func (a api) ByName(ctx context.Context, name string) ([]VM, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not execute VM search request: %w", err)
 	}
+	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
+		return nil, fmt.Errorf("could not execute VM search request, got response %s", httpResponse.Status)
+	}
+
 	var responsePayload response
 	err = json.NewDecoder(httpResponse.Body).Decode(&responsePayload)
 	_ = httpResponse.Body.Close()

--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -68,7 +68,8 @@ var _ = Describe("Vsphere API endpoint tests", func() {
 				definition.SSH = randomPublicSSHKey()
 
 				By("Creating a new VM")
-				provisionResponse, err := vm.NewAPI(cli).Provision(ctx, definition)
+				base64Encoding := true
+				provisionResponse, err := vm.NewAPI(cli).Provision(ctx, definition, base64Encoding)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Waiting for the VM to be ready")


### PR DESCRIPTION
### Description

Added explicit handling for 500 error codes. Avoid trying to decode json.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added explicit handling for 500 error codes. Avoid trying to decode json.
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
