### PR TITLE
Network prefix api update

### DIFF
--- a/pkg/ipam/prefix/prefix.go
+++ b/pkg/ipam/prefix/prefix.go
@@ -58,6 +58,13 @@ type Location struct {
 	CityCode  string `json:"city_code"`
 }
 
+// Vlan reference definition
+type Vlan struct {
+	ID string `json:"identifier"`
+	Name string `json:"name"`
+	CustomerDescription string `json:"description_customer"`
+}
+
 // Info contains extended information about a prefix.
 type Info struct {
 	ID                  string     `json:"identifier"`
@@ -69,8 +76,8 @@ type Info struct {
 	Role                string     `json:"role_text"`
 	Status              string     `json:"status"`
 	Locations           []Location `json:"locations"`
-	VLANID              string     `json:"vlan_id"`
 	RouterRedundancy    bool       `json:"router_redundancy"`
+	vlans []Vlan `json:"vlans"`
 }
 
 // Update contains fields to change on a prefix.

--- a/pkg/ipam/prefix/prefix.go
+++ b/pkg/ipam/prefix/prefix.go
@@ -60,8 +60,8 @@ type Location struct {
 
 // Vlan reference definition
 type Vlan struct {
-	ID string `json:"identifier"`
-	Name string `json:"name"`
+	ID                  string `json:"identifier"`
+	Name                string `json:"name"`
 	CustomerDescription string `json:"description_customer"`
 }
 
@@ -77,7 +77,7 @@ type Info struct {
 	Status              string     `json:"status"`
 	Locations           []Location `json:"locations"`
 	RouterRedundancy    bool       `json:"router_redundancy"`
-	vlans []Vlan `json:"vlans"`
+	vlans               []Vlan     `json:"vlans"`
 }
 
 // Update contains fields to change on a prefix.

--- a/pkg/ipam/prefix/prefix.go
+++ b/pkg/ipam/prefix/prefix.go
@@ -77,7 +77,7 @@ type Info struct {
 	Status              string     `json:"status"`
 	Locations           []Location `json:"locations"`
 	RouterRedundancy    bool       `json:"router_redundancy"`
-	vlans               []Vlan     `json:"vlans"`
+	Vlans               []Vlan     `json:"vlans"`
 }
 
 // Update contains fields to change on a prefix.

--- a/tests/ipam_test.go
+++ b/tests/ipam_test.go
@@ -53,12 +53,16 @@ var _ = Describe("IPAM API endpoint tests", func() {
 			summary, err := p.Create(ctx, prefix.NewCreate(locationID, vlanID, ipV4, prefix.TypePrivate, networkMask))
 			Expect(err).NotTo(HaveOccurred())
 
+			var info prefix.Info
 			By("Waiting for prefix to be 'Active'")
 			Eventually(func() string {
-				info, err := p.Get(ctx, summary.ID)
+				info, err = p.Get(ctx, summary.ID)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(info.Vlans).NotTo(BeNil())
 				return info.Status
 			}, 15*time.Minute, 5*time.Second).Should(Equal("Active"))
+
+			Expect(info.Vlans[0].ID).To(Equal(vlanID))
 
 			By("Updating the prefix")
 			_, err = p.Update(ctx, summary.ID, prefix.Update{CustomerDescription: "something else"})


### PR DESCRIPTION
### Description
Update network prefix Info response model to reflect the changes on API side. To get the vlan ID `vlans` should be used, containing a list of VLANs.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
Updated ipam/prefix Info model for list of VLANs on response.

```release-note

```

### References


### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
