### PR TITLE
Changed location id tag name for info model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.18
+
+BUGFIXES
+
+* Changed location identifier tag name
+
 ## 0.3.17
 
 BUGFIXES  

--- a/pkg/vsphere/info/info.go
+++ b/pkg/vsphere/info/info.go
@@ -19,7 +19,7 @@ type Info struct {
 	CustomName       string     `json:"custom_name"`
 	Identifier       string     `json:"identifier"`
 	GuestOS          string     `json:"guest_os"`
-	LocationID       string     `json:"location_id"`
+	LocationID       string     `json:"location_identifier"`
 	LocationCode     string     `json:"location_code"`
 	LocationCountry  string     `json:"location_country"`
 	LocationName     string     `json:"location_name"`

--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	locationID = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
-	vlanID     = "883003c636644f08a5356078b5fc189d"
+	vlanID     = "02f39d20ca0f4adfb5032f88dbc26c39"
 )
 
 func TestE2E(t *testing.T) {

--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	locationID = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
-	vlanID     = "02f39d20ca0f4adfb5032f88dbc26c39"
+	vlanID     = "883003c636644f08a5356078b5fc189d"
 )
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Roland Urbano <rurbano@anexia-it.com>

### Description

Changed `location_id` to `location_identifier` to reflect the anxcloud API virtual server info response.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):

```release-note
BUGFIXES

* Changed location identifier tag name
```

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
