### PR TITLE
Disk float support

### DIFF
--- a/pkg/vsphere/info/info.go
+++ b/pkg/vsphere/info/info.go
@@ -38,14 +38,14 @@ type Info struct {
 
 // DiskInfo contains meta information of attached disks to a VM.
 type DiskInfo struct {
-	DiskType     string `json:"disk_type"`
-	StorageType  string `json:"storage_type"`
-	BusType      string `json:"bus_type"`
-	BusTypeLabel string `json:"bus_type_label"`
-	DiskGB       int    `json:"disk_gb"`
-	DiskID       int    `json:"disk_id"`
-	IOPS         int    `json:"iops"`
-	Latency      int    `json:"latence"`
+	DiskType     string  `json:"disk_type"`
+	StorageType  string  `json:"storage_type"`
+	BusType      string  `json:"bus_type"`
+	BusTypeLabel string  `json:"bus_type_label"`
+	DiskGB       float32 `json:"disk_gb"`
+	DiskID       int     `json:"disk_id"`
+	IOPS         int     `json:"iops"`
+	Latency      int     `json:"latence"`
 }
 
 // Network contains meta information of attached NICs to a VM.

--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	locationID = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
-	vlanID     = "883003c636644f08a5356078b5fc189d"
+	vlanID     = "02f39d20ca0f4adfb5032f88dbc26c39"
 )
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
### Description

Disk sizes should be floating point values to support all values received from engine.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):

```release-note
*  Changed disk size attribute to floating point value
```


### Community Note

* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
