### PR TITLE
vm_provisioning Flag for VLAN update

### DIFF
--- a/pkg/vlan/vlan.go
+++ b/pkg/vlan/vlan.go
@@ -54,6 +54,7 @@ type CreateDefinition struct {
 // UpdateDefinition contains information required to update a VLAN.
 type UpdateDefinition struct {
 	CustomerDescription string `json:"description_customer,omitempty"`
+	VMProvisioning      bool   `json:"vm_provisioning,omitempty"`
 }
 
 type listResponse struct {

--- a/tests/vlan_test.go
+++ b/tests/vlan_test.go
@@ -53,7 +53,7 @@ var _ = Describe("VLAN API endpoint tests", func() {
 			By("Update the vlan")
 			err = v.Update(ctx, summary.Identifier, vlan.UpdateDefinition{
 				CustomerDescription: "go SDK integration test updated",
-				VMProvisioning: true,
+				VMProvisioning:      true,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -62,7 +62,7 @@ var _ = Describe("VLAN API endpoint tests", func() {
 				vlanInfo, err := v.Get(ctx, summary.Identifier)
 				Expect(err).NotTo(HaveOccurred())
 				return vlanInfo.VMProvisioning
-			}, 5 * time.Minute, 3*time.Second).Should(BeTrue())
+			}, 5*time.Minute, 3*time.Second).Should(BeTrue())
 		})
 
 	})

--- a/tests/vlan_test.go
+++ b/tests/vlan_test.go
@@ -30,11 +30,11 @@ var _ = Describe("VLAN API endpoint tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Should create a VLAN and delete it later", func() {
+		It("Should create a VLAN, update it and delete it later", func() {
 			v := vlan.NewAPI(cli)
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 			defer cancel()
-			summary, err := v.Create(ctx, vlan.CreateDefinition{Location: locationID, CustomerDescription: "go SDK integration test"})
+			summary, err := v.Create(ctx, vlan.CreateDefinition{Location: locationID, VMProvisioning: false, CustomerDescription: "go SDK integration test"})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for vlan to be 'Active'")
@@ -44,9 +44,25 @@ var _ = Describe("VLAN API endpoint tests", func() {
 				return info.Status
 			}, 15*time.Minute, 5*time.Second).Should(Equal("Active"))
 
-			By("Deleting the vlan")
-			err = v.Delete(ctx, summary.Identifier)
+			defer func() {
+				By("Deleting the vlan")
+				err = v.Delete(ctx, summary.Identifier)
+				Expect(err).NotTo(HaveOccurred())
+			}()
+
+			By("Update the vlan")
+			err = v.Update(ctx, summary.Identifier, vlan.UpdateDefinition{
+				CustomerDescription: "go SDK integration test updated",
+				VMProvisioning: true,
+			})
 			Expect(err).NotTo(HaveOccurred())
+
+			By("Fetching the vlan again")
+			Eventually(func() bool {
+				vlanInfo, err := v.Get(ctx, summary.Identifier)
+				Expect(err).NotTo(HaveOccurred())
+				return vlanInfo.VMProvisioning
+			}, 5 * time.Minute, 3*time.Second).Should(BeTrue())
 		})
 
 	})


### PR DESCRIPTION
Signed-off-by: Roland Urbano <rurbano@anexia-it.com>

### Description

Added the `vm_provisioning` flag to the VLAN update structure.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* vlan - added `vm_provisioning` flag to `UpdateDefinition`
```

### References


### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
