### PR TITLE
Added random sleep to IP reservation client

### DIFF
--- a/pkg/ipam/address/address.go
+++ b/pkg/ipam/address/address.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
+	"time"
 )
 
 const (
@@ -263,6 +265,10 @@ func (a api) ReserveRandom(ctx context.Context, reserve ReserveRandom) (ReserveR
 	if err != nil {
 		return ReserveRandomSummary{}, fmt.Errorf("could not create IP address reserve random post request: %w", err)
 	}
+
+	// Workaround to avoid race-conditions on IP reservations for the same VLAN
+	randomDelay := time.Duration(rand.Intn(1000))
+	time.Sleep(randomDelay*time.Millisecond)
 
 	httpResponse, err := a.client.Do(req)
 	if err != nil {

--- a/pkg/ipam/address/address.go
+++ b/pkg/ipam/address/address.go
@@ -268,7 +268,7 @@ func (a api) ReserveRandom(ctx context.Context, reserve ReserveRandom) (ReserveR
 
 	// Workaround to avoid race-conditions on IP reservations for the same VLAN
 	randomDelay := time.Duration(rand.Intn(1000))
-	time.Sleep(randomDelay*time.Millisecond)
+	time.Sleep(randomDelay * time.Millisecond)
 
 	httpResponse, err := a.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Roland Urbano <rurbano@anexia-it.com>

### Description

Add random sleep delay to `ReserveRandom` API to work-a-round a race-condition when reserving IPs on the same VLAN concurrently.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* ipam/address - random sleep added to ip reservation as workaround
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
