### PR TITLE
Changed float32 to float64 on disk size

### DIFF
--- a/pkg/vsphere/info/info.go
+++ b/pkg/vsphere/info/info.go
@@ -42,7 +42,7 @@ type DiskInfo struct {
 	StorageType  string  `json:"storage_type"`
 	BusType      string  `json:"bus_type"`
 	BusTypeLabel string  `json:"bus_type_label"`
-	DiskGB       float32 `json:"disk_gb"`
+	DiskGB       float64 `json:"disk_gb"`
 	DiskID       int     `json:"disk_id"`
 	IOPS         int     `json:"iops"`
 	Latency      int     `json:"latence"`

--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Vsphere API endpoint tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vmInfo).NotTo(BeNil())
 			Expect(vmInfo.Disks).To(Equal(1))
-			expectedDiskSize := float32(10)
+			expectedDiskSize := 10.00
 			Expect(vmInfo.DiskInfo[0].DiskGB).To(Equal(expectedDiskSize))
 
 		})


### PR DESCRIPTION
Signed-off-by: Roland Urbano <rurbano@anexia-it.com>

### Description

Changed the disk size variable from float32 to float64 as this should be the native size and provides some additional performance boost.

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
