### PR TITLE
Updated Changelog for v0.3.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.20
+
+BUGFIXES
+
+* vsphere/info - `DiskGB` variable type changed from float32 to float64
+
 ## 0.3.19
 
 ENHANCEMENTS


### PR DESCRIPTION
Signed-off-by: Roland Urbano <rurbano@anexia-it.com>

### Description

Update Changelog for version 0.3.20

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUGFIXES

* vsphere/info - `DiskGB` variable type changed from float32 to float64
```


### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
