### PR TITLE
Provide request/response logging capabilities

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: run linters
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint
+          make tools
           golangci-lint run --config .golangci.yml
           make fmtcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.20
+
+BUGFIXES
+
+* vsphere/info - `DiskGB` variable type changed from float32 to float64
+
 ## 0.3.19
 
 ENHANCEMENTS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anexia-it/go-anxcloud
 
-go 1.14
+go 1.15
 
 require (
 	github.com/onsi/ginkgo v1.12.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anexia-it/go-anxcloud
 
-go 1.15
+go 1.14
 
 require (
 	github.com/onsi/ginkgo v1.12.1

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,6 @@ go 1.15
 require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.4
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -21,6 +23,11 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.4 h1:NiTx7EEvBzu9sFOD1zORteLSt3o8gnlvZZwSE9TnY9U=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
@@ -59,3 +66,5 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -90,7 +90,7 @@ func handleRequest(c *http.Client, req *http.Request, logWriter io.Writer) (*htt
 
 func dumpRequest(req *http.Request) ([]byte, error) {
 	clonedRequest := req.Clone(context.Background())
-	clonedRequest.Header.Set("Authorization","REDACTED")
+	clonedRequest.Header.Set("Authorization", "REDACTED")
 
 	return httputil.DumpRequestOut(req, true)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -92,7 +92,7 @@ func dumpRequest(req *http.Request) ([]byte, error) {
 	clonedRequest := req.Clone(context.Background())
 	clonedRequest.Header.Set("Authorization", "REDACTED")
 
-	return httputil.DumpRequestOut(req, true)
+	return httputil.DumpRequestOut(clonedRequest, true)
 }
 
 type optionSet struct {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,10 +2,13 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"time"
 )
@@ -57,23 +60,45 @@ func (r ResponseError) Error() string {
 	return fmt.Sprintf("received error from api: %+v", r.ErrorData)
 }
 
-func handleRequest(c *http.Client, req *http.Request) (*http.Response, error) {
+func handleRequest(c *http.Client, req *http.Request, logWriter io.Writer) (*http.Response, error) {
+	if logWriter != nil {
+		reqBytes, dumpErr := dumpRequest(req)
+		if dumpErr == nil {
+			fmt.Fprintf(logWriter, "request: %s\n", string(reqBytes))
+		}
+	}
 	response, err := c.Do(req)
+
 	if err == nil && response.StatusCode != http.StatusOK {
 		errResponse := ResponseError{Request: req, Response: response}
 		if decodeErr := json.NewDecoder(response.Body).Decode(&errResponse); decodeErr != nil {
 			return response, fmt.Errorf("could not decode error response: %w", decodeErr)
 		}
 
-		return response, &errResponse
+		err = &errResponse
+	}
+
+	if logWriter != nil {
+		respBytes, dumpErr := httputil.DumpResponse(response, err == nil)
+		if dumpErr == nil {
+			fmt.Fprintf(logWriter, "response: %s\n", string(respBytes))
+		}
 	}
 
 	return response, err
 }
 
+func dumpRequest(req *http.Request) ([]byte, error) {
+	clonedRequest := req.Clone(context.Background())
+	clonedRequest.Header.Set("Authorization","REDACTED")
+
+	return httputil.DumpRequestOut(req, true)
+}
+
 type optionSet struct {
 	httpClient *http.Client
 	token      string
+	logWriter  io.Writer
 }
 
 // Option is a optional parameter for the New method.
@@ -111,6 +136,15 @@ func TokenFromEnv(unset bool) Option {
 	}
 }
 
+// LogWriter configures the debug writer for logging requests and responses
+func LogWriter(w io.Writer) Option {
+	return func(o *optionSet) error {
+		o.logWriter = w
+
+		return nil
+	}
+}
+
 // HTTPClient lets the client use the given http.Client.
 func HTTPClient(c *http.Client) Option {
 	return func(o *optionSet) error {
@@ -139,7 +173,11 @@ func New(options ...Option) (Client, error) {
 	}
 
 	if optionSet.token != "" {
-		return &tokenClient{optionSet.token, optionSet.httpClient}, nil
+		return &tokenClient{
+			token:      optionSet.token,
+			httpClient: optionSet.httpClient,
+			logWriter:  optionSet.logWriter,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("%w: token not set", ErrConfiguration)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -19,6 +19,8 @@ func TestClient_handleRequest(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			formValue := r.FormValue("foo")
 			assert.EqualValues(t, "bar", formValue)
+			assert.EqualValues(t, "sensible-value", r.Header.Get("Authorization"))
+
 			_, err := io.WriteString(w, formValue)
 			assert.NoError(t, err)
 		})
@@ -54,6 +56,7 @@ func TestClient_handleRequest(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			formValue := r.FormValue("foo")
 			assert.EqualValues(t, "bar", formValue)
+			assert.EqualValues(t, "sensible-value", r.Header.Get("Authorization"))
 
 			errorMsg := map[string]string{
 				"msg": "error message",

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -15,12 +15,13 @@ import (
 )
 
 func TestClient_handleRequest(t *testing.T) {
-	//log.SetOutput(ioutil.Discard)
+	log.SetOutput(ioutil.Discard)
 	t.Run("Success", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			formValue := r.FormValue("foo")
 			assert.EqualValues(t, "bar", formValue)
-			io.WriteString(w, formValue)
+			_, err := io.WriteString(w, formValue)
+			assert.NoError(t, err)
 		})
 
 		srv := httptest.NewServer(handler)
@@ -56,7 +57,7 @@ func TestClient_handleRequest(t *testing.T) {
 			}
 			encoder := json.NewEncoder(w)
 			w.WriteHeader(http.StatusBadRequest)
-			encoder.Encode(errorMsg)
+			assert.NoError(t, encoder.Encode(errorMsg))
 		})
 
 		srv := httptest.NewServer(handler)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestClient_handleRequest(t *testing.T) {
+	//log.SetOutput(ioutil.Discard)
+	t.Run("Success", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			formValue := r.FormValue("foo")
+			assert.EqualValues(t, "bar", formValue)
+			io.WriteString(w, formValue)
+		})
+
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		data := url.Values{}
+		data.Set("foo", "bar")
+		encData := data.Encode()
+		req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(encData))
+		if err != nil {
+			panic(err)
+		}
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(encData)))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Authorization", "sensible-value")
+
+		response, err := handleRequest(http.DefaultClient, req, log.Writer())
+		assert.NoError(t, err)
+		if assert.NotNil(t, response) {
+			body, err := ioutil.ReadAll(response.Body)
+			assert.NoError(t, err)
+			assert.EqualValues(t, "bar", body)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			formValue := r.FormValue("foo")
+			assert.EqualValues(t, "bar", formValue)
+
+			errorMsg := map[string]string{
+				"msg": "error message",
+			}
+			encoder := json.NewEncoder(w)
+			w.WriteHeader(http.StatusBadRequest)
+			encoder.Encode(errorMsg)
+		})
+
+		srv := httptest.NewServer(handler)
+		defer srv.Close()
+
+		data := url.Values{}
+		data.Set("foo", "bar")
+		encData := data.Encode()
+		req, err := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(encData))
+		if err != nil {
+			panic(err)
+		}
+		req.Header.Set("Content-Length", fmt.Sprintf("%d", len(encData)))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Authorization", "sensible-value")
+
+		response, err := handleRequest(http.DefaultClient, req, log.Writer())
+		assert.Error(t, err)
+		if assert.NotNil(t, response) {
+			assert.EqualValues(t, response.StatusCode, http.StatusBadRequest)
+		}
+	})
+}

--- a/pkg/client/test.go
+++ b/pkg/client/test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 )
@@ -9,6 +11,7 @@ type testClient struct {
 	baseClient Client
 	baseURL    string
 	httpClient *http.Client
+	logWriter io.Writer
 }
 
 func (t testClient) BaseURL() string {
@@ -20,7 +23,7 @@ func (t testClient) Do(req *http.Request) (*http.Response, error) {
 		return t.baseClient.Do(req)
 	}
 
-	return handleRequest(t.httpClient, req)
+	return handleRequest(t.httpClient, req, t.logWriter)
 }
 
 // NewTestClient creates a new client for testing.
@@ -33,7 +36,7 @@ func (t testClient) Do(req *http.Request) (*http.Response, error) {
 // used httptest.Server that should be closed after test completion.
 func NewTestClient(c Client, handler http.Handler) (Client, *httptest.Server) {
 	server := httptest.NewServer(handler)
-	cw := testClient{c, server.URL, &http.Client{}}
+	cw := testClient{c, server.URL, &http.Client{}, log.Writer()}
 
 	return cw, server
 }

--- a/pkg/client/test.go
+++ b/pkg/client/test.go
@@ -11,7 +11,7 @@ type testClient struct {
 	baseClient Client
 	baseURL    string
 	httpClient *http.Client
-	logWriter io.Writer
+	logWriter  io.Writer
 }
 
 func (t testClient) BaseURL() string {

--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -9,7 +9,7 @@ import (
 type tokenClient struct {
 	token      string
 	httpClient *http.Client
-	logWriter io.Writer
+	logWriter  io.Writer
 }
 
 func (t tokenClient) BaseURL() string {

--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -2,12 +2,14 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 )
 
 type tokenClient struct {
 	token      string
 	httpClient *http.Client
+	logWriter io.Writer
 }
 
 func (t tokenClient) BaseURL() string {
@@ -17,5 +19,5 @@ func (t tokenClient) BaseURL() string {
 func (t tokenClient) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("Token %v", t.token))
 
-	return handleRequest(t.httpClient, req)
+	return handleRequest(t.httpClient, req, t.logWriter)
 }

--- a/pkg/client/token_test.go
+++ b/pkg/client/token_test.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/anexia-it/go-anxcloud/pkg/test/echo"
+	"log"
 	"net/http"
 	"testing"
 )
 
 func TestTokenClient(t *testing.T) {
 	dummyToken := "ie7dois8Ooquoo1ieB9kae8Od9ooshee3nejuach4inae3gai0Re0Shaipeihail" //nolint:gosec // Not a real token.
-	c, err := client.New(client.TokenFromString(dummyToken))
+	c, err := client.New(client.TokenFromString(dummyToken), client.LogWriter(log.Writer()))
 	if err != nil {
 		t.Errorf("could not create client: %v", err)
 	}


### PR DESCRIPTION
### Description

Ths PR adds logging capabilities to the client implementation. When configured, it writes both request and response to the configured `io.Writer`. 

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* client/option: Added `io.Writer` to log request and response
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
