### PR TITLE
Fix a bug where 404 from progress API results in a loop until timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.24
+
+ENHANCEMENTS
+
+* vsphere/progress Fix a bug where 404 from progress API results in a loop until timeout
+
 ## 0.3.23
 
 ENHANCEMENTS

--- a/pkg/vsphere/provisioning/progress/progress.go
+++ b/pkg/vsphere/provisioning/progress/progress.go
@@ -100,6 +100,7 @@ func (a api) AwaitCompletion(ctx context.Context, progressID string) (string, er
 			isProvisioningError := errors.As(err, &responseError)
 			switch {
 			case isProvisioningError && responseError.Response.StatusCode == 404:
+				return "", fmt.Errorf("could not get progress. Endpoint returned 404: %w", err)
 			case err == nil:
 				if progressResponse.Progress == progressCompleteValue {
 					return progressResponse.VMIdentifier, nil

--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -5,12 +5,13 @@ import (
 	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"fmt"
-	"github.com/anexia-it/go-anxcloud/pkg/vsphere/info"
-	"github.com/anexia-it/go-anxcloud/pkg/vsphere/vmlist"
 	"log"
 	"math/rand"
 	"strings"
 	"time"
+
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/info"
+	"github.com/anexia-it/go-anxcloud/pkg/vsphere/vmlist"
 
 	cpuperformancetype "github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/cpuperformancetypes"
 	"github.com/anexia-it/go-anxcloud/pkg/vsphere/provisioning/disktype"
@@ -205,6 +206,18 @@ var _ = Describe("Vsphere API endpoint tests", func() {
 			Expect(vmInfo.Disks).To(Equal(1))
 			expectedDiskSize := 10.00
 			Expect(vmInfo.DiskInfo[0].DiskGB).To(Equal(expectedDiskSize))
+
+		})
+	})
+
+	Context("Progress Endpoint", func() {
+		It("Should handle 404 correctly", func() {
+			By("using an identifiert which does not exist")
+			ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancelFunc()
+			progress, err := progress.NewAPI(cli).AwaitCompletion(ctx, "this-id-does-not-exist")
+			Expect(progress).To(BeEmpty())
+			Expect(err).NotTo(BeNil())
 
 		})
 	})


### PR DESCRIPTION
### Description

The removed empty case didn't do anything. Go has no automatic fall through in cases. This code was looped until there was a timeout of the context

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix a bug where 404 from progress API results in a loop until timeout
```

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
