### PR TITLE
Allow to specify a user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GITTAG ?= $(shell git describe --tags --always)
 GITCOMMIT ?= $(shell git log -1 --pretty=format:"%H")
-GOLDFLAGS ?= -s -w -extldflags '-zrelro -znow' -X github.com/anexia-it/go-anxcloud/pkg/client.version=$(GITTAG) -X github.com/anexia-it/go-anxcloud/pkg/client.commit=$(GITCOMMIT)
+GOLDFLAGS ?= -s -w -extldflags '-zrelro -znow' -X github.com/anexia-it/go-anxcloud/pkg/client.version=$(GITTAG)
 GOFLAGS ?= -trimpath
 CGO_ENABLED ?= 0
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GITTAG ?= $(shell git describe --tags --always)
 GITCOMMIT ?= $(shell git log -1 --pretty=format:"%H")
-GOLDFLAGS ?= -s -w -extldflags '-zrelro -znow' -X github.com/anexia-it/go-anxcloud.version=$(GITTAG) -X github.com/anexia-it/go-anxcloud.commit=$(GITCOMMIT)
+GOLDFLAGS ?= -s -w -extldflags '-zrelro -znow' -X github.com/anexia-it/go-anxcloud/pkg/client.version=$(GITTAG) -X github.com/anexia-it/go-anxcloud/pkg/client.commit=$(GITCOMMIT)
 GOFLAGS ?= -trimpath
 CGO_ENABLED ?= 0
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,9 +37,6 @@ var ErrEnvMissing = errors.New("environment variable missing")
 var (
 	// Version gets set by linker at build time
 	version = "snapshot"
-
-	// Commit gets set by linker at build time
-	commit = "deadbeef"
 )
 
 // Client interacts with the anxcloud API.
@@ -197,7 +194,7 @@ func New(options ...Option) (Client, error) {
 	}
 
 	if optionSet.userAgent == "" {
-		optionSet.userAgent = fmt.Sprintf("go-anxcloud / %s-%s (%s)", version, commit, runtime.GOOS)
+		optionSet.userAgent = fmt.Sprintf("go-anxcloud / %s (%s)", version, runtime.GOOS)
 	}
 
 	if optionSet.token != "" {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -194,7 +194,7 @@ func New(options ...Option) (Client, error) {
 	}
 
 	if optionSet.userAgent == "" {
-		optionSet.userAgent = fmt.Sprintf("go-anxcloud / %s (%s)", version, runtime.GOOS)
+		optionSet.userAgent = fmt.Sprintf("go-anxcloud/%s (%s)", version, runtime.GOOS)
 	}
 
 	if optionSet.token != "" {

--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -10,6 +10,7 @@ type tokenClient struct {
 	token      string
 	httpClient *http.Client
 	logWriter  io.Writer
+	userAgent  string
 }
 
 func (t tokenClient) BaseURL() string {
@@ -18,6 +19,6 @@ func (t tokenClient) BaseURL() string {
 
 func (t tokenClient) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("Token %v", t.token))
-
+	req.Header.Set("User-Agent", t.userAgent)
 	return handleRequest(t.httpClient, req, t.logWriter)
 }

--- a/pkg/client/useragent_test.go
+++ b/pkg/client/useragent_test.go
@@ -38,7 +38,7 @@ func TestWithNoAgent(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAgent := r.Header.Get("User-Agent")
-		require.Equal(t, fmt.Sprintf("go-anxcloud / %s (%s)", "snapshot", runtime.GOOS), receivedAgent)
+		require.Equal(t, fmt.Sprintf("go-anxcloud/%s (%s)", "snapshot", runtime.GOOS), receivedAgent)
 		echo.TestMock(t).ServeHTTP(w, r)
 	})
 

--- a/pkg/client/useragent_test.go
+++ b/pkg/client/useragent_test.go
@@ -38,7 +38,7 @@ func TestWithNoAgent(t *testing.T) {
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedAgent := r.Header.Get("User-Agent")
-		require.Equal(t, fmt.Sprintf("go-anxcloud / %s-%s (%s)", "snapshot", "deadbeef", runtime.GOOS), receivedAgent)
+		require.Equal(t, fmt.Sprintf("go-anxcloud / %s (%s)", "snapshot", runtime.GOOS), receivedAgent)
 		echo.TestMock(t).ServeHTTP(w, r)
 	})
 

--- a/pkg/client/useragent_test.go
+++ b/pkg/client/useragent_test.go
@@ -1,0 +1,51 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/test/echo"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"runtime"
+	"testing"
+)
+
+func TestUserAgent(t *testing.T) {
+	t.Parallel()
+	testUserAgent := "userAgentTest"
+	c, err := client.New(client.TokenFromString("Test"), client.UserAgent(testUserAgent))
+	require.NoError(t, err)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAgent := r.Header.Get("User-Agent")
+		require.Equal(t, testUserAgent, receivedAgent)
+		echo.TestMock(t).ServeHTTP(w, r)
+	})
+
+	cw, server := client.NewTestClient(c, handler)
+
+	ctx := context.Background()
+	err = echo.NewAPI(cw).Echo(ctx)
+	require.NoError(t, err)
+	defer server.Close()
+}
+
+func TestWithNoAgent(t *testing.T) {
+	t.Parallel()
+	c, err := client.New(client.TokenFromString("Test"))
+	require.NoError(t, err)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAgent := r.Header.Get("User-Agent")
+		require.Equal(t, fmt.Sprintf("go-anxcloud / %s-%s (%s)", "snapshot", "deadbeef", runtime.GOOS), receivedAgent)
+		echo.TestMock(t).ServeHTTP(w, r)
+	})
+
+	cw, server := client.NewTestClient(c, handler)
+
+	ctx := context.Background()
+	err = echo.NewAPI(cw).Echo(ctx)
+	require.NoError(t, err)
+	defer server.Close()
+}

--- a/tools/main.go
+++ b/tools/main.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main


### PR DESCRIPTION
### Description

Allow to specify a user agent during a client creation

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS

client - Add client option to provide a user agent
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
