### PR TITLE
Return Progress Identifier on Deprovision API Call

### DIFF
--- a/pkg/vsphere/provisioning/vm/api.go
+++ b/pkg/vsphere/provisioning/vm/api.go
@@ -9,7 +9,7 @@ import (
 // API contains methods for VM provisioning.
 type API interface {
 	NewDefinition(location, templateType, templateID, hostname string, cpus, memory, disk int, network []Network) Definition
-	Deprovision(ctx context.Context, identifier string, delayed bool) error
+	Deprovision(ctx context.Context, identifier string, delayed bool) (DeprovisionResponse, error)
 	Provision(ctx context.Context, definition Definition, base64Encoding bool) (ProvisioningResponse, error)
 	Update(ctx context.Context, vmID string, change Change) (ProvisioningResponse, error)
 }

--- a/pkg/vsphere/provisioning/vm/deprovision.go
+++ b/pkg/vsphere/provisioning/vm/deprovision.go
@@ -2,9 +2,15 @@ package vm
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 )
+
+type DeprovisionResponse struct {
+	Identifier             string `json:"identifier"`
+	DeleteWillBeExecutedAt string `json:"delete_will_be_executed_at"`
+}
 
 // Deprovision issues a request to deprovision an existing VM using.
 //
@@ -15,7 +21,7 @@ import (
 // delayed indicated that the VM shall be removed with a delay of 24h.
 //
 // If the API returns errors, they are raised as ResponseError error.
-func (a api) Deprovision(ctx context.Context, identifier string, delayed bool) error {
+func (a api) Deprovision(ctx context.Context, identifier string, delayed bool) (DeprovisionResponse, error) {
 	url := fmt.Sprintf(
 		"%s%s/%s?delayed=%t",
 		a.client.BaseURL(),
@@ -26,22 +32,24 @@ func (a api) Deprovision(ctx context.Context, identifier string, delayed bool) e
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
 	if err != nil {
-		return fmt.Errorf("could not create VM deprovisioning request: %w", err)
+		return DeprovisionResponse{}, fmt.Errorf("could not create VM deprovisioning request: %w", err)
 	}
 
 	httpResponse, err := a.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("could not execute VM deprovisioning request: %w", err)
+		return DeprovisionResponse{}, fmt.Errorf("could not execute VM deprovisioning request: %w", err)
 	}
+	defer httpResponse.Body.Close()
 	if httpResponse.StatusCode >= 500 && httpResponse.StatusCode < 600 {
-		return fmt.Errorf("could not execute VM deprovisioning request, got response %s", httpResponse.Status)
+		return DeprovisionResponse{}, fmt.Errorf("could not execute VM deprovisioning request, got response %s", httpResponse.Status)
 	}
 
-	_ = httpResponse.Body.Close()
+	var payload DeprovisionResponse
+	err = json.NewDecoder(httpResponse.Body).Decode(&payload)
 
 	if err != nil {
-		return fmt.Errorf("could not decode VM deprovisioning response: %w", err)
+		return DeprovisionResponse{}, fmt.Errorf("could not decode VM deprovisioning response: %w", err)
 	}
 
-	return err
+	return payload, nil
 }

--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -106,8 +106,12 @@ var _ = Describe("Vsphere API endpoint tests", func() {
 				}
 
 				By("Deleting the VM")
-				err = vm.NewAPI(cli).Deprovision(ctx, vmID, false)
+				response, err := vm.NewAPI(cli).Deprovision(ctx, vmID, false)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(response.Identifier).ToNot(BeEmpty())
+				returnedIdent, err := progress.NewAPI(cli).AwaitCompletion(ctx, response.Identifier)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(returnedIdent).To(BeEquivalentTo(vmID))
 			})
 		})
 


### PR DESCRIPTION
### Description

The Deprovision endpoint returns an progress identifier, which allows to use the existing `AwaitCompletion` function to block until the VM disappears. 

PS. Tests is adjusted to await the deletion now

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* vsphere - Deprovision now returns progress identifier
```
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
