### PR TITLE
Add Prefix type to prefix info 

### DIFF
--- a/pkg/ipam/prefix/prefix.go
+++ b/pkg/ipam/prefix/prefix.go
@@ -78,6 +78,7 @@ type Info struct {
 	Locations           []Location `json:"locations"`
 	RouterRedundancy    bool       `json:"router_redundancy"`
 	Vlans               []Vlan     `json:"vlans"`
+	PrefixType          int        `json:"type"`
 }
 
 // Update contains fields to change on a prefix.

--- a/tests/ipam_test.go
+++ b/tests/ipam_test.go
@@ -59,6 +59,7 @@ var _ = Describe("IPAM API endpoint tests", func() {
 				info, err = p.Get(ctx, summary.ID)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(info.Vlans).NotTo(BeNil())
+				Expect(info.PrefixType).To(BeEquivalentTo(prefix.TypePrivate))
 				return info.Status
 			}, 15*time.Minute, 5*time.Second).Should(Equal("Active"))
 


### PR DESCRIPTION
### Description

Return type of the prefix


### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* ipam/prefix - return type from API 
```

