### PR TITLE
Allow to create empty prefixes

### DIFF
--- a/pkg/ipam/address/api.go
+++ b/pkg/ipam/address/api.go
@@ -2,14 +2,15 @@ package address
 
 import (
 	"context"
-
 	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/utils/param"
 )
 
 // API contains methods for IP manipulation.
 type API interface {
 	List(ctx context.Context, page, limit int, search string) ([]Summary, error)
 	Get(ctx context.Context, id string) (Address, error)
+	GetFiltered(ctx context.Context, page, limit int, filters ...param.Parameter) ([]Summary, error)
 	Delete(ctx context.Context, id string) error
 	Create(ctx context.Context, create Create) (Summary, error)
 	Update(ctx context.Context, id string, update Update) (Summary, error)

--- a/pkg/ipam/prefix/prefix.go
+++ b/pkg/ipam/prefix/prefix.go
@@ -28,6 +28,7 @@ type Create struct {
 	NetworkMask int    `json:"netmask"`
 
 	CreateVLAN              bool   `json:"new_vlan,omitempty"`
+	CreateEmpty             bool   `json:"create_empty"`
 	VLANID                  string `json:"vlan,omitempty"`
 	EnableRedundancy        bool   `json:"router_redundancy,omitempty"`
 	EnableVMProvisioning    bool   `json:"vm_provisioning,omitempty"`

--- a/pkg/utils/param/param.go
+++ b/pkg/utils/param/param.go
@@ -1,0 +1,13 @@
+package param
+
+import "net/url"
+
+type Parameter func(values url.Values)
+
+func ParameterBuilder(filterKey string) func(string) Parameter {
+	return func(filterValue string) Parameter {
+		return func(values url.Values) {
+			values.Set(filterKey, filterValue)
+		}
+	}
+}

--- a/pkg/vsphere/provisioning/templates/templates.go
+++ b/pkg/vsphere/provisioning/templates/templates.go
@@ -76,7 +76,7 @@ type Template struct {
 	Name       string     `json:"name"`
 	WordSize   string     `json:"bit"`
 	Build      string     `json:"build"`
-	Parameters Parameters `json:"params"`
+	Parameters Parameters `json:"param"`
 }
 
 const (

--- a/tests/param_test.go
+++ b/tests/param_test.go
@@ -1,0 +1,21 @@
+package tests_test
+
+import (
+	"github.com/anexia-it/go-anxcloud/pkg/utils/param"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/url"
+)
+
+var _ = Describe("Parameter Builder Tests", func() {
+	It("Should Create Parameter", func() {
+		const testKey = "testKey"
+		const testValue = "testValue"
+		builder := param.ParameterBuilder(testKey)
+		parameter := builder(testValue)
+
+		values := url.Values{}
+		parameter(values)
+		Expect(values.Get(testKey)).To(BeEquivalentTo(testValue))
+	})
+})


### PR DESCRIPTION
### Description

The Anexia API allows to to create an empty prefix when the given flag is specified.

also added the GetFiltered method for address retrieval and a general purpos packag for query parameter building

### Release Note

```release-note
* ipam/prefix - allow to create empty prefixes
* ipam/address - allow to retrieve addresses with given filters
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
