### PR TITLE
✨➕🔊: change client logging to use logr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/anexia-it/go-anxcloud
 go 1.15
 
 require (
+	github.com/go-logr/logr v1.1.0
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.4
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-logr/logr v1.1.0 h1:nAbevmWlS2Ic4m4+/An5NXkaGqlqpbBgdcuThZxnZyI=
+github.com/go-logr/logr v1.1.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,10 +1,8 @@
 package client
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +10,9 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClient_handleRequest(t *testing.T) {
@@ -39,17 +40,13 @@ func TestClient_handleRequest(t *testing.T) {
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Authorization", "sensible-value")
 
-		buffer := make([]byte, 0)
-		writeBuffer := bytes.NewBuffer(buffer)
-
-		response, err := handleRequest(http.DefaultClient, req, writeBuffer)
+		response, err := handleRequest(http.DefaultClient, req, logr.Discard())
 		assert.NoError(t, err)
 		if assert.NotNil(t, response) {
 			body, err := ioutil.ReadAll(response.Body)
 			assert.NoError(t, err)
 			assert.EqualValues(t, "bar", body)
 		}
-		assert.True(t, strings.Contains(writeBuffer.String(), "Authorization: REDACTED"))
 	})
 
 	t.Run("Error", func(t *testing.T) {
@@ -80,14 +77,10 @@ func TestClient_handleRequest(t *testing.T) {
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Authorization", "sensible-value")
 
-		buffer := make([]byte, 0)
-		writeBuffer := bytes.NewBuffer(buffer)
-
-		response, err := handleRequest(http.DefaultClient, req, writeBuffer)
+		response, err := handleRequest(http.DefaultClient, req, logr.Discard())
 		assert.Error(t, err)
 		if assert.NotNil(t, response) {
 			assert.EqualValues(t, response.StatusCode, http.StatusBadRequest)
 		}
-		assert.True(t, strings.Contains(writeBuffer.String(), "Authorization: REDACTED"))
 	})
 }

--- a/pkg/client/log_utils.go
+++ b/pkg/client/log_utils.go
@@ -1,0 +1,140 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/go-logr/logr"
+	logfuncr "github.com/go-logr/logr/funcr"
+)
+
+const (
+	// LogVerbosityRequests is the verbosity level for requests and responses.
+	LogVerbosityRequests = 3
+
+	// LogNameTrace is the name of the logger used for logging requests and responses.
+	LogNameTrace = "trace"
+)
+
+func ioLogger(w io.Writer) logr.Logger {
+	l := logfuncr.New(
+		func(prefix, args string) {
+			fmt.Fprintf(w, "%s\t%s\n", prefix, args)
+		},
+		logfuncr.Options{
+			LogTimestamp: true,
+
+			// we are logging request and response with verbosity 3 and since this is the only
+			// thing we log and this option is for compatibility with previous versions, we set
+			// this verbosity here.
+			Verbosity: LogVerbosityRequests,
+		},
+	)
+
+	return l
+}
+
+func traceLogger(log logr.Logger) logr.Logger {
+	return log.WithName(LogNameTrace).V(LogVerbosityRequests)
+}
+
+func logRequest(req *http.Request, logger logr.Logger) {
+	log := traceLogger(logger)
+
+	if req == nil || !log.Enabled() {
+		return
+	}
+
+	headers := req.Header.Clone()
+	headers.Set("Authorization", "REDACTED")
+
+	if body := stringifyBody(&req.Body, logger); body != nil {
+		log = log.WithValues("body", body)
+	}
+
+	log.Info("Sending request to Engine",
+		"url", req.URL.String(),
+		"headers", stringifyHeaders(headers),
+		"method", req.Method,
+	)
+}
+
+func logResponse(res *http.Response, logger logr.Logger) {
+	log := traceLogger(logger)
+
+	if res == nil || !log.Enabled() {
+		return
+	}
+
+	headers := res.Header.Clone()
+	headers.Set("Set-Cookie", "REDACTED")
+
+	if body := stringifyBody(&res.Body, logger); body != nil {
+		log = log.WithValues("body", body)
+	}
+
+	if res.Request != nil {
+		log = log.WithValues(
+			"url", res.Request.URL.String(),
+			"method", res.Request.Method,
+		)
+	}
+
+	log.Info("Received response from Engine",
+		"headers", stringifyHeaders(headers),
+		"statusCode", res.StatusCode,
+	)
+}
+
+func stringifyBody(body *io.ReadCloser, log logr.Logger) *string {
+	if body != nil {
+		b, err := ioutil.ReadAll(*body)
+		if err != nil {
+			log.Error(err, "Error while preparing to log body, not logging it")
+		} else {
+			*body = ioutil.NopCloser(bytes.NewBuffer(b))
+
+			ret := string(b)
+			return &ret
+		}
+	}
+
+	return nil
+}
+
+func stringifyHeaders(headers http.Header) string {
+	entries := make([]string, 0, len(headers))
+
+	for header, values := range headers {
+		// we sort the values to have an easier time reading the produced logs
+		// ... also makes testing easier
+		sort.Strings(values)
+
+		// sometimes it's interesting to see what is _not_ in go's standard library ...
+		// can I have some functional go pls? perhaps a slices.Map(array, func(entry))?
+		quoted := make([]string, len(values))
+		for i, val := range values {
+			quoted[i] = fmt.Sprintf("'%s'", val)
+		}
+
+		var arrayEnclOpen, arrayEnclClose string
+
+		if len(values) > 1 {
+			arrayEnclOpen = "["
+			arrayEnclClose = "]"
+		}
+
+		entries = append(entries, fmt.Sprintf("%s: %v%s%v", header, arrayEnclOpen, strings.Join(quoted, ", "), arrayEnclClose))
+	}
+
+	// we sort our headers to have an easier time reading the produced logs
+	// ... also helps with testing
+	sort.Strings(entries)
+
+	return strings.Join(entries, ", ")
+}

--- a/pkg/client/log_utils_test.go
+++ b/pkg/client/log_utils_test.go
@@ -1,0 +1,131 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_traceLogging(t *testing.T) {
+	logger := funcr.New(
+		func(prefix, args string) {
+			message := fmt.Sprintf("%s\t%s\n", prefix, args)
+
+			if strings.Contains(message, "Authorization") {
+				assert.Contains(t, message, "REDACTED")
+				assert.NotContains(t, message, "auth_token")
+			}
+
+			if strings.Contains(message, "Set-Cookie") {
+				assert.Contains(t, message, "REDACTED")
+				assert.NotContains(t, message, "session_id")
+			}
+		},
+		funcr.Options{
+			Verbosity: 3,
+		},
+	)
+
+	t.Run("Check Authorization redacted in request", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/foo", nil)
+		req.Header.Add("Authorization", "auth_token")
+
+		logRequest(req, logger)
+	})
+
+	t.Run("Check Set-Cookie header redacted in response", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		cookie := http.Cookie{
+			Name:  "Session-Cookie",
+			Value: "session_id",
+		}
+
+		http.SetCookie(w, &cookie)
+		written, err := w.Write([]byte("OK"))
+		assert.Equal(t, 2, written)
+		assert.NoError(t, err)
+
+		logResponse(w.Result(), logger)
+	})
+
+	t.Run("Check request body intact after logging", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/foo", bytes.NewBuffer([]byte("OK")))
+
+		logRequest(req, logger)
+
+		if body, err := ioutil.ReadAll(req.Body); err != nil {
+			t.Error(err)
+		} else {
+			assert.Equal(t, []byte("OK"), body)
+		}
+	})
+
+	t.Run("Check response body intact after logging", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		written, err := w.Write([]byte("OK"))
+		assert.Equal(t, 2, written)
+		assert.NoError(t, err)
+
+		res := w.Result()
+
+		logResponse(res, logger)
+
+		if body, err := ioutil.ReadAll(res.Body); err != nil {
+			t.Error(err)
+		} else {
+			assert.Equal(t, []byte("OK"), body)
+		}
+	})
+
+	t.Run("Check if logger is disabled on lower verbosity", func(t *testing.T) {
+		logger := funcr.New(
+			func(prefix, args string) {
+				assert.Fail(t, "We shouldn't have logged anything")
+			},
+			funcr.Options{
+				Verbosity: 0,
+			},
+		)
+
+		assert.False(t, logger.V(3).Enabled())
+
+		req := httptest.NewRequest("GET", "/foo", bytes.NewBuffer([]byte("OK")))
+		logRequest(req, logger)
+	})
+
+	t.Run("Check not crashing on nil requests", func(t *testing.T) {
+		logRequest(nil, logger)
+	})
+
+	t.Run("Check not crashing on nil responses", func(t *testing.T) {
+		logResponse(nil, logger)
+	})
+
+	t.Run("Test Header stringification", func(t *testing.T) {
+		headers := make(http.Header, 2)
+		headers.Add("Foxes", "are cool")
+
+		// this should be sorted to the start
+		headers.Add("000", "1234")
+
+		// add values for Foo in wrongly sorted order to test values are sorted
+		headers.Add("Foo", "Baz")
+		headers.Add("Foo", "Bar")
+
+		headerString := stringifyHeaders(headers)
+
+		assert.Contains(t, headerString, "Foo: ['Bar', 'Baz']")
+		assert.Contains(t, headerString, "Foxes: 'are cool'")
+
+		assert.Equal(t, "000: '1234', Foo: ['Bar', 'Baz'], Foxes: 'are cool'", headerString)
+	})
+}

--- a/pkg/client/test.go
+++ b/pkg/client/test.go
@@ -1,16 +1,17 @@
 package client
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/go-logr/logr"
 )
 
 type testClient struct {
 	baseClient Client
 	baseURL    string
 	httpClient *http.Client
-	logWriter  io.Writer
+	logger     logr.Logger
 }
 
 func (t testClient) BaseURL() string {
@@ -22,7 +23,7 @@ func (t testClient) Do(req *http.Request) (*http.Response, error) {
 		return t.baseClient.Do(req)
 	}
 
-	return handleRequest(t.httpClient, req, t.logWriter)
+	return handleRequest(t.httpClient, req, t.logger)
 }
 
 // NewTestClient creates a new client for testing.
@@ -35,7 +36,7 @@ func (t testClient) Do(req *http.Request) (*http.Response, error) {
 // used httptest.Server that should be closed after test completion.
 func NewTestClient(c Client, handler http.Handler) (Client, *httptest.Server) {
 	server := httptest.NewServer(handler)
-	cw := testClient{c, server.URL, &http.Client{}, nil}
+	cw := testClient{c, server.URL, &http.Client{}, logr.Discard()}
 
 	return cw, server
 }

--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -2,14 +2,15 @@ package client
 
 import (
 	"fmt"
-	"io"
 	"net/http"
+
+	"github.com/go-logr/logr"
 )
 
 type tokenClient struct {
 	token      string
 	httpClient *http.Client
-	logWriter  io.Writer
+	logger     logr.Logger
 	userAgent  string
 }
 
@@ -20,5 +21,5 @@ func (t tokenClient) BaseURL() string {
 func (t tokenClient) Do(req *http.Request) (*http.Response, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("Token %v", t.token))
 	req.Header.Set("User-Agent", t.userAgent)
-	return handleRequest(t.httpClient, req, t.logWriter)
+	return handleRequest(t.httpClient, req, t.logger)
 }

--- a/pkg/client/token_test.go
+++ b/pkg/client/token_test.go
@@ -3,16 +3,16 @@ package client_test
 import (
 	"context"
 	"fmt"
-	"github.com/anexia-it/go-anxcloud/pkg/client"
-	"github.com/anexia-it/go-anxcloud/pkg/test/echo"
-	"log"
 	"net/http"
 	"testing"
+
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/test/echo"
 )
 
 func TestTokenClient(t *testing.T) {
 	dummyToken := "ie7dois8Ooquoo1ieB9kae8Od9ooshee3nejuach4inae3gai0Re0Shaipeihail" //nolint:gosec // Not a real token.
-	c, err := client.New(client.TokenFromString(dummyToken), client.LogWriter(log.Writer()))
+	c, err := client.New(client.TokenFromString(dummyToken))
 	if err != nil {
 		t.Errorf("could not create client: %v", err)
 	}


### PR DESCRIPTION
### Description

Using logr allows us to use structured logging without depending on a specific logging implementation. Compatibility with previous logging interface is added, with deprecation notice in doc comment and in logs on using the old option.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):

```release-note
* pkg/client now uses `logr` for logging. If you used the `LogWriter` option before (for dumping requests and responses), a warning will be logged, telling you to use the new `Logger` option.
```

### References

* https://pkg.go.dev/github.com/go-logr/logr@v1.1.0
* https://dave.cheney.net/2015/11/05/lets-talk-about-logging

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
