### PR TITLE
New generic API client for less code duplication

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"context"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+// TODO(LittleFox94): Maybe Client is a better name for this, but
+// we'd then have to rename client to transport
+
+// API is the interface to perform operations on the engine.
+type API interface {
+	// Get the identified object from the engine. Set the identifying attribute on the
+	// object passed to this function.
+	Get(context.Context, types.IdentifiedObject, ...GetOption) error
+
+	// Create the given object on the engine.
+	Create(context.Context, types.Object, ...CreateOption) error
+
+	// Update the object on the engine.
+	Update(context.Context, types.IdentifiedObject, ...UpdateOption) error
+
+	// Destroy the identified object.
+	Destroy(context.Context, types.IdentifiedObject, ...DestroyOption) error
+
+	// List objects matching the info given in the object.
+	List(context.Context, types.FilterObject, ...ListOption) error
+}

--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -1,0 +1,216 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/lbaas/backend"
+	lbaasCommon "github.com/anexia-it/go-anxcloud/pkg/lbaas/common"
+	"github.com/anexia-it/go-anxcloud/pkg/lbaas/loadbalancer"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+func ExampleNewAPI() {
+	api, err := NewAPI(
+		// you might find client.TokenFromEnv(false) useful
+		WithClientOptions(client.TokenFromString("bogus auth token")),
+	)
+
+	if err != nil {
+		log.Fatalf("Error creating api instance: %v\n", err)
+	} else {
+		// do something with api
+		lb := loadbalancer.Loadbalancer{Identifier: "bogus identifier"}
+		if err := api.Get(context.TODO(), &lb); IgnoreNotFound(err) != nil {
+			fmt.Printf("Error retrieving loadbalancer with identifier '%v'\n", lb.Identifier)
+		}
+	}
+
+	// fails because we didn't pass a valid auth token nor a valid identifier
+
+	// Output: Error retrieving loadbalancer with identifier 'bogus identifier'
+}
+
+func Example_usage() {
+	// see example on NewAPI how to implement this function
+	apiClient := newExampleAPI()
+
+	// retrieve and create backend, handling errors along the way.
+	backend := backend.Backend{Identifier: "bogus identifier 1"}
+	if err := apiClient.Get(context.TODO(), &backend); IgnoreNotFound(err) != nil {
+		fmt.Printf("Fatal error while retrieving backend: %v\n", err)
+	} else if err != nil {
+		fmt.Printf("Backend not yet existing, creating ...\n")
+
+		backend.Name = "backend-01"
+		backend.Mode = lbaasCommon.HTTP
+		// [...]
+
+		if err := apiClient.Create(context.TODO(), &backend); err != nil {
+			fmt.Printf("Fatal error while creating backend: %v\n", err)
+		}
+	} else {
+		fmt.Printf("Found backend with name %v and mode %v\n", backend.Name, backend.Mode)
+		fmt.Printf("Deleting it for fun and profit :)\n")
+
+		if err := apiClient.Destroy(context.TODO(), &backend); err != nil {
+			fmt.Printf("Error destroying the backend: %v", err)
+		}
+	}
+
+	// Output:
+	// Found backend with name Example-Backend and mode tcp
+	// Deleting it for fun and profit :)
+}
+
+func ExampleAPI_create() {
+	// see example on NewAPI how to implement this function
+	apiClient := newExampleAPI()
+
+	backend := backend.Backend{
+		Name: "backend-01",
+		Mode: lbaasCommon.HTTP,
+		// [...]
+	}
+
+	if err := apiClient.Create(context.TODO(), &backend); err != nil {
+		fmt.Printf("Error creating backend: %v\n", err)
+	} else {
+		fmt.Printf("Created backend '%v', engine assigned identifier '%v'\n", backend.Name, backend.Identifier)
+	}
+
+	// Output: Created backend 'backend-01', engine assigned identifier 'generated identifier 1'
+}
+
+func ExampleAPI_destroy() {
+	// see example on NewAPI how to implement this function
+	apiClient := newExampleAPI()
+
+	backend := backend.Backend{Identifier: "bogus identifier 1"}
+	if err := apiClient.Destroy(context.TODO(), &backend); err != nil {
+		fmt.Printf("Error destroying backend: %v\n", err)
+	} else {
+		fmt.Printf("Successfully destroyed backend\n")
+	}
+
+	// Output: Successfully destroyed backend
+}
+
+func ExampleAPI_get() {
+	// see example on NewAPI how to implement this function
+	apiClient := newExampleAPI()
+
+	backend := backend.Backend{Identifier: "bogus identifier 1"}
+	if err := apiClient.Get(context.TODO(), &backend); err != nil {
+		fmt.Printf("Error retrieving backend: %v\n", err)
+	} else {
+		fmt.Printf("Got backend named \"%v\"\n", backend.Name)
+	}
+
+	// Output: Got backend named "Example-Backend"
+}
+
+func ExampleAPI_listPaged() {
+	// see example on NewAPI how to implement this function
+	apiClient := newExampleAPI()
+
+	// list all backends, with 10 entries per page and starting on first page.
+	b := backend.Backend{}
+	var pageIter types.PageInfo
+	if err := apiClient.List(context.TODO(), &b, Paged(0, 10, &pageIter)); err != nil {
+		fmt.Printf("Error listing backends: %v\n", err)
+	} else {
+		var backends []backend.Backend
+		for pageIter.Next(&backends) {
+			for _, backend := range backends {
+				fmt.Printf("Got backend named \"%v\"\n", backend.Name)
+			}
+		}
+
+		if err := pageIter.Error(); err != nil {
+			// Handle error catched while iterating pages.
+			// Errors will prevent pageIter.Next() to continue, you can call pageIter.ResetError() to resume.
+			fmt.Printf("Error while iterating pages of backends: %v\n", err)
+		}
+	}
+
+	// Output:
+	// Got backend named "Example-Backend"
+	// Got backend named "backend-01"
+}
+
+func ExampleAPI_listChannel() {
+	// see example on NewAPI how to implement this function
+	apiClient := newExampleAPI()
+
+	channel := make(types.ObjectChannel)
+
+	// list all backends using a channel and have the library handle the paging.
+	// Oh and we filter by LoadBalancer, because we can and the example has to be somewhere.
+	b := backend.Backend{LoadBalancer: loadbalancer.LoadBalancerInfo{Identifier: "bogus identifier 2"}}
+	if err := apiClient.List(context.TODO(), &b, AsObjectChannel(&channel)); err != nil {
+		fmt.Printf("Error listing backends: %v\n", err)
+	} else {
+		for res := range channel {
+			if err = res(&b); err != nil {
+				fmt.Printf("Error retrieving backend from channel: %v\n", err)
+				break
+			}
+
+			fmt.Printf("Got backend named \"%v\"\n", b.Name)
+		}
+	}
+
+	// Output:
+	// Got backend named "Example-Backend"
+}
+
+func ExampleAPI_update() {
+	// see example on NewAPI how to implement this function
+	apiClient := newExampleAPI()
+
+	b := backend.Backend{
+		Identifier: "bogus identifier 1",
+		Name:       "Updated backend",
+		Mode:       lbaasCommon.HTTP,
+		// [...]
+	}
+
+	if err := apiClient.Update(context.TODO(), &b); err != nil {
+		fmt.Printf("Error updating backend: %v\n", err)
+	} else {
+		fmt.Printf("Successfully updated backend\n")
+
+		retrieved := backend.Backend{Identifier: "bogus identifier 1"}
+		if err := apiClient.Get(context.TODO(), &retrieved); err != nil {
+			fmt.Printf("Error verifying updated backend: %v\n", err)
+		} else {
+			fmt.Printf("Backend is now renamed to '%v' and has mode %v\n", retrieved.Name, retrieved.Mode)
+		}
+	}
+
+	// Output:
+	// Successfully updated backend
+	// Backend is now renamed to 'Updated backend' and has mode http
+}
+
+// creates a new API instance for using the examples as tests. Includes a mock server.
+func newExampleAPI() API {
+	server := newMockServer()
+
+	apiClient, err := NewAPI(
+		WithClientOptions(
+			client.BaseURL(server.URL()),
+			client.TokenFromString("bogus testing token"),
+		),
+	)
+	if err != nil {
+		log.Fatalf("Error creating API client: %v\n", err)
+		return nil
+	}
+
+	return apiClient
+}

--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -1,0 +1,423 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"path"
+	"reflect"
+	"strconv"
+
+	"github.com/go-logr/logr"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+)
+
+const (
+	// ListChannelDefaultPageSize specifies the default page size for List operations returning the data via channel.
+	ListChannelDefaultPageSize = 10
+)
+
+// defaultAPI is the type for our generic implementation of the API interface.
+type defaultAPI struct {
+	client client.Client
+	logger *logr.Logger
+
+	clientOptions []client.Option
+}
+
+// NewAPIOption is the type for giving options to the NewAPI function.
+type NewAPIOption func(*defaultAPI)
+
+// WithClientOptions configures the API to pass the given client.Option to the client when creating it.
+func WithClientOptions(o ...client.Option) NewAPIOption {
+	return func(a *defaultAPI) {
+		a.clientOptions = append(a.clientOptions, o...)
+	}
+}
+
+// WithLogger configures the API to use the given logger. It is recommended to pass a named logger.
+// If you don't pass an existing client, the logger you give here will given to the client (with
+// added name "client").
+func WithLogger(l logr.Logger) NewAPIOption {
+	return func(a *defaultAPI) {
+		a.logger = &l
+		a.clientOptions = append(a.clientOptions, client.Logger(l.WithName("client")))
+	}
+}
+
+// NewAPI creates a new API client which implements the API interface.
+func NewAPI(opts ...NewAPIOption) (API, error) {
+	api := defaultAPI{
+		clientOptions: []client.Option{
+			client.ParseEngineErrors(false),
+		},
+	}
+
+	for _, opt := range opts {
+		opt(&api)
+	}
+
+	if api.client == nil {
+		if c, err := client.New(api.clientOptions...); err == nil {
+			api.client = c
+		} else {
+			return nil, err
+		}
+	}
+
+	return api, nil
+}
+
+// Get the identified object from the engine.
+func (a defaultAPI) Get(ctx context.Context, o types.IdentifiedObject, opts ...types.GetOption) error {
+	options := types.GetOptions{}
+	for _, opt := range opts {
+		opt.ApplyToGet(&options)
+	}
+
+	return a.do(ctx, o, o, &options, types.OperationGet)
+}
+
+// Create the given object on the engine.
+func (a defaultAPI) Create(ctx context.Context, o types.Object, opts ...types.CreateOption) error {
+	options := types.CreateOptions{}
+	for _, opt := range opts {
+		opt.ApplyToCreate(&options)
+	}
+
+	return a.do(ctx, o, o, &options, types.OperationCreate)
+}
+
+// Update the object on the engine.
+func (a defaultAPI) Update(ctx context.Context, o types.IdentifiedObject, opts ...types.UpdateOption) error {
+	options := types.UpdateOptions{}
+	for _, opt := range opts {
+		opt.ApplyToUpdate(&options)
+	}
+
+	return a.do(ctx, o, o, &options, types.OperationUpdate)
+}
+
+// Destroy the identified object.
+func (a defaultAPI) Destroy(ctx context.Context, o types.IdentifiedObject, opts ...types.DestroyOption) error {
+	options := types.DestroyOptions{}
+	for _, opt := range opts {
+		opt.ApplyToDestroy(&options)
+	}
+
+	return a.do(ctx, o, o, &options, types.OperationDestroy)
+}
+
+// List objects matching the info given in the object.
+func (a defaultAPI) List(ctx context.Context, o types.FilterObject, opts ...types.ListOption) error {
+	options := types.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(&options)
+	}
+
+	var err error
+	ctx, err = a.contextPrepare(ctx, o, types.OperationList)
+
+	if err != nil {
+		return err
+	}
+
+	req, err := a.makeRequest(ctx, o, nil, &options, types.OperationList)
+	if err != nil {
+		return err
+	}
+
+	var channelPageIterator types.PageInfo
+	if options.ObjectChannel != nil && !options.Paged {
+		options.Paged = true
+		options.Page = 1
+		options.EntriesPerPage = ListChannelDefaultPageSize
+		options.PageInfo = &channelPageIterator
+	} else if options.ObjectChannel != nil && options.PageInfo != nil {
+		return ErrCannotListChannelAndPaged
+	}
+
+	if options.Paged {
+		addPaginationQueryParameters(ctx, req, options)
+	}
+
+	result := json.RawMessage{}
+	err = a.doRequest(req, o, &result, &options, types.OperationList)
+	if err != nil {
+		return err
+	}
+
+	if options.Paged {
+		fetcher := func(page uint) (json.RawMessage, error) {
+			req := req.Clone(ctx)
+
+			query := req.URL.Query()
+			query.Set("page", strconv.FormatUint(uint64(page), 10))
+
+			req.URL.RawQuery = query.Encode()
+
+			var response json.RawMessage
+			err := a.doRequest(req, o, &response, &options, types.OperationList)
+			if err != nil {
+				return nil, err
+			}
+
+			return response, nil
+		}
+
+		iter, err := newPageIter(ctx, result, options, fetcher)
+		if err != nil {
+			return err
+		}
+
+		*options.PageInfo = iter
+	}
+
+	if options.ObjectChannel != nil {
+		go func(c types.ObjectChannel, pi types.PageInfo) {
+			var pageData []json.RawMessage
+
+			for pi.Next(&pageData) {
+				for _, o := range pageData {
+					c <- func(out types.Object) error {
+						return json.Unmarshal(o, out)
+					}
+				}
+			}
+
+			close(c)
+		}(*options.ObjectChannel, channelPageIterator)
+	}
+
+	return nil
+}
+
+func (a defaultAPI) makeRequest(ctx context.Context, obj types.Object, body interface{}, opts types.Options, op types.Operation) (*http.Request, error) {
+	singleObjectOperation := op == types.OperationGet || op == types.OperationUpdate || op == types.OperationDestroy
+
+	// We do this right on top because this checks if the Object has a correct type which is more strictly defined than just the interface.
+	// In a perfect world this would be a compile-time check.
+	identifier, err := getObjectIdentifier(obj, singleObjectOperation)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceURL, err := obj.EndpointURL(ctx, op, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	baseURL, err := url.Parse(a.client.BaseURL())
+	if err != nil {
+		return nil, fmt.Errorf("error parsing client's BaseURL: %w", err)
+	}
+
+	fullResourcePath := path.Join(baseURL.Path, resourceURL.Path)
+
+	if singleObjectOperation {
+		fullResourcePath = path.Join(fullResourcePath, identifier)
+	}
+
+	fullQuery := baseURL.Query()
+	resourceQuery := resourceURL.Query()
+	for key, vals := range resourceQuery {
+		for _, val := range vals {
+			fullQuery.Add(key, val)
+		}
+	}
+
+	fullURL := url.URL{
+		Scheme: baseURL.Scheme,
+		// Opaque URLs are not supported by us
+		User:     baseURL.User,
+		Host:     baseURL.Host,
+		Path:     fullResourcePath,
+		RawQuery: fullQuery.Encode(),
+		// Fragment is never sent to a server
+	}
+
+	var method string
+	hasRequestBody := false
+
+	switch op {
+	case types.OperationGet:
+		fallthrough
+	case types.OperationList:
+		method = "GET"
+
+	case types.OperationCreate:
+		method = "POST"
+		hasRequestBody = true
+	case types.OperationUpdate:
+		method = "PUT"
+		hasRequestBody = true
+	case types.OperationDestroy:
+		method = "DELETE"
+	default:
+		return nil, ErrOperationNotSupported
+	}
+
+	var bodyReader io.Reader = nil
+
+	if hasRequestBody {
+		buffer := bytes.Buffer{}
+
+		var requestBody interface{} = body
+
+		if filterRequestBody, ok := obj.(types.RequestBodyHook); ok {
+			rb, err := filterRequestBody.FilterAPIRequestBody(op, opts)
+
+			if err != nil {
+				return nil, err
+			}
+
+			requestBody = rb
+		}
+
+		if err := json.NewEncoder(&buffer).Encode(requestBody); err != nil {
+			return nil, err
+		}
+
+		bodyReader = &buffer
+	}
+
+	request, err := http.NewRequestWithContext(ctx, method, fullURL.String(), bodyReader)
+	if err != nil {
+		// currently unreachable. http.NewRequestWithContext() returns an error in the following cases:
+		// * the passed method is invalid (we have a hardcoded list of methods we use some lines above)
+		// * ctx is nil (we check that in prepareContext() already)
+		// * the URL cannot be parsed (we check that already some lines above)
+		// makes it non-testable right now, but, I don't care since it's because of all errors already handled.
+		// -- Mara @LittleFox94 Grosch, 2021-10-27
+		return nil, err
+	}
+
+	if hasRequestBody {
+		request.Header.Add("Content-Type", "application/json; charset=utf-8")
+	}
+
+	if filterRequest, ok := obj.(types.RequestFilterHook); ok {
+		request, err = filterRequest.FilterAPIRequest(op, opts, request)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return request, nil
+}
+
+func (a defaultAPI) doRequest(req *http.Request, obj types.Object, body interface{}, opts types.Options, op types.Operation) error {
+	response, err := a.client.Do(req)
+
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+
+	if filterResponse, ok := obj.(types.ResponseFilterHook); ok {
+		response, err = filterResponse.FilterAPIResponse(op, opts, response)
+	}
+
+	if err != nil {
+		return fmt.Errorf("Object returned an error from FilterAPIResponse: %w", err)
+	}
+
+	defer response.Body.Close()
+
+	if err := errorFromResponse(req, response); err != nil {
+		return err
+	}
+
+	if mediaType, err := getResponseType(response); err == nil {
+		if mediaType == "application/json" {
+			return json.NewDecoder(response.Body).Decode(body)
+		}
+
+		// unreachable, getResponseType() already checks for supported types
+		return ErrUnsupportedResponseFormat
+	} else {
+		return err
+	}
+}
+
+func (a defaultAPI) contextPrepare(ctx context.Context, o types.Object, op types.Operation) (context.Context, error) {
+	if ctx == nil {
+		return nil, ErrContextRequired
+	}
+
+	objectType := reflect.TypeOf(o)
+	for objectType.Kind() == reflect.Ptr {
+		objectType = objectType.Elem()
+	}
+
+	logger := logr.Discard()
+
+	// Checking if we have a logger on the context and attach one if we don't.
+	if l, err := logr.FromContext(ctx); err != nil && a.logger != nil {
+		logger = *a.logger
+	} else if err == nil {
+		// TODO(LittleFox94): derive a named one from this?
+		logger = l
+	}
+
+	return logr.NewContext(ctx, logger.WithValues("operation", op, "resource", objectType)), nil
+}
+
+func (a defaultAPI) do(ctx context.Context, obj types.Object, body interface{}, opts types.Options, op types.Operation) error {
+	var err error
+	ctx, err = a.contextPrepare(ctx, obj, types.OperationList)
+
+	if err != nil {
+		return err
+	}
+
+	request, err := a.makeRequest(ctx, obj, body, opts, op)
+	if err != nil {
+		return err
+	}
+
+	return a.doRequest(request, obj, body, opts, op)
+}
+
+func getResponseType(res *http.Response) (string, error) {
+	knownTypes := []string{"application/json"}
+
+	if contentType := res.Header.Get("content-type"); contentType != "" {
+		mt, _, err := mime.ParseMediaType(contentType)
+
+		if err != nil {
+			return "", fmt.Errorf("error parsing Content-Type header in Engine response: %w (was: '%v')", err, contentType)
+		}
+
+		for _, kt := range knownTypes {
+			if kt == mt {
+				return mt, nil
+			}
+		}
+
+		return "", fmt.Errorf("%w: unknown mime-type %v", ErrUnsupportedResponseFormat, mt)
+	}
+
+	return "application/json", nil
+}
+
+func addPaginationQueryParameters(ctx context.Context, req *http.Request, opts types.ListOptions) {
+	if opts.Page == 0 {
+		log := logr.FromContextOrDiscard(ctx)
+		log.V(1).Info("List called requesting page 0, fixing to page 1")
+
+		opts.Page = 1
+	}
+
+	query := req.URL.Query()
+	query.Add("page", strconv.FormatUint(uint64(opts.Page), 10))
+	query.Add("limit", strconv.FormatUint(uint64(opts.EntriesPerPage), 10))
+
+	req.URL.RawQuery = query.Encode()
+}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,0 +1,595 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("getResponseType function", func() {
+	It("returns the mime type for valid data", func() {
+		rec := httptest.NewRecorder()
+		rec.Header().Add("Content-Type", "application/json; charset=utf-8")
+		rec.WriteHeader(500)
+
+		ret, err := getResponseType(rec.Result())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ret).To(Equal("application/json"))
+	})
+
+	It("returns an error for invalid mime type data", func() {
+		rec := httptest.NewRecorder()
+		rec.Header().Add("Content-Type", "foo/bar; foo")
+		rec.WriteHeader(500)
+
+		ret, err := getResponseType(rec.Result())
+
+		Expect(err).To(MatchError(mime.ErrInvalidMediaParameter))
+		Expect(ret).To(Equal(""))
+	})
+
+	It("returns an error for valid but unknown mime type", func() {
+		rec := httptest.NewRecorder()
+		rec.Header().Add("Content-Type", "application/pdf")
+		rec.WriteHeader(500)
+
+		ret, err := getResponseType(rec.Result())
+
+		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(MatchError(mime.ErrInvalidMediaParameter))
+		Expect(err.Error()).To(ContainSubstring("application/pdf"))
+		Expect(ret).To(Equal(""))
+	})
+
+	It("returns the JSON mime type when no Content-Type header is present", func() {
+		rec := httptest.NewRecorder()
+		rec.WriteHeader(500)
+
+		ret, err := getResponseType(rec.Result())
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ret).To(Equal("application/json"))
+	})
+})
+
+type api_test_anyop_option string
+
+func (o api_test_anyop_option) ApplyToGet(opts *types.GetOptions) {
+	_ = opts.Set("api_test_option", o, false)
+}
+
+func (o api_test_anyop_option) ApplyToList(opts *types.ListOptions) {
+	_ = opts.Set("api_test_option", o, false)
+}
+
+func (o api_test_anyop_option) ApplyToCreate(opts *types.CreateOptions) {
+	_ = opts.Set("api_test_option", o, false)
+}
+
+func (o api_test_anyop_option) ApplyToUpdate(opts *types.UpdateOptions) {
+	_ = opts.Set("api_test_option", o, false)
+}
+
+func (o api_test_anyop_option) ApplyToDestroy(opts *types.DestroyOptions) {
+	_ = opts.Set("api_test_option", o, false)
+}
+
+type api_test_object struct {
+	Val string `json:"value" anxcloud:"identifier"`
+}
+
+var api_test_error = errors.New("we shall fail")
+
+func (o *api_test_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	if o.Val == "failing" {
+		return nil, api_test_error
+	} else if o.Val == "option-check" {
+		expected_option_value := ctx.Value(api_test_error)
+
+		if v, err := opts.Get("api_test_option"); err != nil {
+			return nil, err
+		} else if v != expected_option_value {
+			return nil, api_test_error
+		}
+	}
+
+	logger := logr.FromContextOrDiscard(ctx)
+	logger.Info("Hello from api_test_object!")
+
+	u, _ := url.ParseRequestURI("/resource/v1")
+	return u, nil
+}
+
+func (o *api_test_object) FilterAPIRequest(op types.Operation, opts types.Options, req *http.Request) (*http.Request, error) {
+	if o.Val == "failing_filter_request" {
+		return nil, api_test_error
+	}
+
+	return req, nil
+}
+
+func (o *api_test_object) FilterAPIResponse(op types.Operation, opts types.Options, res *http.Response) (*http.Response, error) {
+	if o.Val == "failing_filter_response" {
+		return nil, api_test_error
+	}
+
+	return res, nil
+}
+
+func (o *api_test_object) FilterAPIRequestBody(op types.Operation, opts types.Options) (interface{}, error) {
+	if o.Val == "failing_filter_request_body" {
+		return nil, api_test_error
+	} else if o.Val == "function_filter_request_body" {
+		return func() {}, nil
+	}
+
+	return o, nil
+}
+
+type api_test_error_roundtripper bool
+
+func (rt api_test_error_roundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, api_test_error
+}
+
+type api_test_nonstruct_object bool
+
+func (o *api_test_nonstruct_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+type api_test_nonpointer_object bool
+
+func (o api_test_nonpointer_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+type api_test_noident_object struct {
+	Value string `json:"value"`
+}
+
+func (o api_test_noident_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+type api_test_invalidident_object struct {
+	Value int `json:"value" anxcloud:"identifier"`
+}
+
+func (o api_test_invalidident_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+var _ = Describe("creating API with different options", func() {
+	var server *ghttp.Server
+
+	BeforeEach(func() {
+		server = ghttp.NewServer()
+	})
+
+	It("barks when creating a client without token and without ignoring the missing token", func() {
+		_, err := NewAPI()
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("barks when making a request while using a client with unparsable BaseURL", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL("as.lfdna,smdnasd:::"), // a keysmash, added ::: to have it a really unparsable URL
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+		err = api.Create(context.TODO(), &o)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("error parsing client's BaseURL"))
+	})
+
+	It("attaches the given logger to context", func() {
+		server.SetAllowUnhandledRequests(true)
+
+		log := strings.Builder{}
+
+		logger := funcr.New(
+			func(prefix, args string) {
+				_, _ = log.WriteString(prefix + "\t" + args + "\n")
+			},
+			funcr.Options{
+				Verbosity: 3,
+			})
+
+		api, err := NewAPI(
+			WithLogger(logger),
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+		err = api.Create(context.TODO(), &o)
+		Expect(err).To(HaveOccurred())
+
+		Expect(log.String()).To(ContainSubstring("Hello from api_test_object!"))
+	})
+
+	It("uses a logger already on the context", func() {
+		server.SetAllowUnhandledRequests(true)
+
+		log := strings.Builder{}
+
+		logger := funcr.New(
+			func(prefix, args string) {
+				_, _ = log.WriteString(prefix + "\t" + args + "\n")
+			},
+			funcr.Options{
+				Verbosity: 3,
+			})
+
+		ctx := logr.NewContext(context.TODO(), logger)
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+		err = api.Create(ctx, &o)
+		Expect(err).To(HaveOccurred())
+
+		Expect(log.String()).To(ContainSubstring("Hello from api_test_object!"))
+	})
+
+	It("handles the Object returning an error on EndpointURL", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"failing"}
+		err = api.Create(context.TODO(), &o)
+		Expect(err).To(MatchError(api_test_error))
+
+		err = api.List(context.TODO(), &o)
+		Expect(err).To(MatchError(api_test_error))
+	})
+
+	It("handles the Object returning an empty identifier on EndpointURL for operations requiring an IdentifiedObject", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{""}
+		err = api.Get(context.TODO(), &o)
+		Expect(err).To(MatchError(ErrUnidentifiedObject))
+	})
+
+	It("handles the Object returning an error on FilterAPIRequest", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"failing_filter_request"}
+		err = api.Create(context.TODO(), &o)
+		Expect(err).To(MatchError(api_test_error))
+	})
+
+	It("handles the Object returning an error on FilterAPIRequestBody", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"failing_filter_request_body"}
+		err = api.Create(context.TODO(), &o)
+		Expect(err).To(MatchError(api_test_error))
+	})
+
+	It("handles the Object returning a request body that cannot be encoded in json on FilterAPIRequestBody", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"function_filter_request_body"}
+		err = api.Create(context.TODO(), &o)
+
+		var e *json.UnsupportedTypeError
+		Expect(errors.As(err, &e)).To(BeTrue())
+	})
+
+	It("handles the Object returning an error on FilterAPIResponse", func() {
+		server.SetAllowUnhandledRequests(true)
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"failing_filter_response"}
+		err = api.Create(context.TODO(), &o)
+		Expect(err).To(MatchError(api_test_error))
+	})
+
+	It("handles the Engine returning a weird response content-type", func() {
+		server.AppendHandlers(ghttp.RespondWith(200, nil, http.Header{"Content-Type": []string{"application/octet-stream"}}))
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+		err = api.Get(context.TODO(), &o)
+		Expect(err).To(MatchError(ErrUnsupportedResponseFormat))
+	})
+
+	It("handles the Engine returning bad responses for List requests", func() {
+		server.AppendHandlers(
+			ghttp.RespondWith(200, `foo no json`, http.Header{"Content-Type": []string{"application/json"}}),
+			ghttp.RespondWithJSONEncoded(200, []map[string]string{{"value": "hello world"}}),
+			ghttp.RespondWith(200, `foo no json`, http.Header{"Content-Type": []string{"application/json"}}),
+			ghttp.RespondWithJSONEncoded(200, map[string]string{"foo": "hello world"}),
+		)
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+
+		var pi types.PageInfo
+		err = api.List(context.TODO(), &o, Paged(1, 1, &pi))
+
+		var e *json.SyntaxError
+		Expect(errors.As(err, &e)).To(BeTrue())
+
+		err = api.List(context.TODO(), &o, Paged(1, 1, &pi))
+		Expect(err).NotTo(HaveOccurred())
+
+		var os []api_test_object
+		ok := pi.Next(&os)
+		Expect(pi.Error()).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		ok = pi.Next(&os)
+		Expect(ok).To(BeFalse())
+		Expect(errors.As(pi.Error(), &e)).To(BeTrue())
+
+		err = api.List(context.TODO(), &o, Paged(1, 1, &pi))
+		Expect(err).To(MatchError(ErrPageResponseNotSupported))
+	})
+
+	It("handles users trying to list with page iterator and channel simultaneously", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+
+		var pi types.PageInfo
+		oc := make(types.ObjectChannel)
+		err = api.List(context.TODO(), &o, Paged(1, 2, &pi), AsObjectChannel(&oc))
+		Expect(err).To(MatchError(ErrCannotListChannelAndPaged))
+	})
+
+	It("handles users trying to list page 0", func() {
+		server.AppendHandlers(ghttp.RespondWithJSONEncoded(200, []string{}))
+
+		log := strings.Builder{}
+
+		logger := funcr.New(
+			func(prefix, args string) {
+				_, _ = log.WriteString(prefix + "\t" + args + "\n")
+			},
+			funcr.Options{
+				Verbosity: 3,
+			})
+
+		api, err := NewAPI(
+			WithLogger(logger),
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+
+		var pi types.PageInfo
+		err = api.List(context.TODO(), &o, Paged(0, 2, &pi))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(log.String()).To(ContainSubstring("requesting page 0, fixing to page 1"))
+	})
+
+	It("handles http.Client.Do() returning an error", func() {
+		hc := http.Client{
+			Transport: api_test_error_roundtripper(false),
+		}
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.WithClient(&hc),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+		err = api.Get(context.TODO(), &o)
+		Expect(err).To(MatchError(api_test_error))
+	})
+
+	It("handles not being given a context", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		// the two nolint comments are for passing nil context, which is the behavior we want to test here.
+
+		o := api_test_object{"identifier"}
+		err = api.Get(nil, &o) //nolint:golint,staticcheck
+		Expect(err).To(MatchError(ErrContextRequired))
+
+		err = api.List(nil, &o) //nolint:golint,staticcheck
+		Expect(err).To(MatchError(ErrContextRequired))
+	})
+
+	It("handles bogus operations", func() {
+		api, err := NewAPI(
+			WithClientOptions(
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+		req, err := api.(defaultAPI).makeRequest(context.TODO(), &o, &o, &types.ListOptions{}, types.Operation("bogus operation"))
+		Expect(err).To(MatchError(ErrOperationNotSupported))
+		Expect(req).To(BeNil())
+	})
+
+	It("consumes the given options for all operations", func() {
+		opt := api_test_anyop_option("hello world")
+		ctx := context.WithValue(context.TODO(), api_test_error, opt)
+
+		server.AppendHandlers(
+			ghttp.RespondWithJSONEncoded(200, map[string]string{"value": "option-check"}),
+			ghttp.RespondWithJSONEncoded(200, map[string]string{"value": "option-check"}),
+			ghttp.RespondWithJSONEncoded(200, []map[string]string{{"value": "option-check"}}),
+			ghttp.RespondWithJSONEncoded(200, map[string]string{"value": "option-check"}),
+			ghttp.RespondWithJSONEncoded(200, map[string]string{}),
+		)
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"option-check"}
+
+		err = api.Create(ctx, &o, opt)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.Get(ctx, &o, opt)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.List(ctx, &o, opt)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.Update(ctx, &o, opt)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.Destroy(ctx, &o, opt)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("getObjectIdentifier function", func() {
+	It("errors out on invalid Object types", func() {
+		nso := api_test_nonstruct_object(false)
+		identifier, err := getObjectIdentifier(&nso, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("must be implemented as structs"))
+		Expect(identifier).To(BeEmpty())
+
+		npo := api_test_nonpointer_object(false)
+		identifier, err = getObjectIdentifier(npo, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("must be implemented on a pointer to struct"))
+		Expect(identifier).To(BeEmpty())
+
+		nio := api_test_noident_object{"invalid"}
+		identifier, err = getObjectIdentifier(&nio, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("lacks identifier field"))
+		Expect(identifier).To(BeEmpty())
+
+		iio := api_test_invalidident_object{32}
+		identifier, err = getObjectIdentifier(&iio, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("identifier field has an unsupported type"))
+		Expect(identifier).To(BeEmpty())
+	})
+
+	Context("when doing an operation on a specific object", func() {
+		It("errors out on valid Object type but empty identifier", func() {
+			o := api_test_object{""}
+			identifier, err := getObjectIdentifier(&o, true)
+			Expect(err).To(MatchError(ErrUnidentifiedObject))
+			Expect(identifier).To(BeEmpty())
+		})
+
+		It("returns the correct identifier", func() {
+			o := api_test_object{"test"}
+			identifier, err := getObjectIdentifier(&o, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identifier).To(Equal("test"))
+		})
+	})
+})
+
+func TestAPIUnits(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "api unit test suite")
+}

--- a/pkg/api/doc.go
+++ b/pkg/api/doc.go
@@ -1,0 +1,7 @@
+// Package api implements a generic API client for our engine, reducing the amount of duplicated code in
+// this library.
+//
+// It is heavily inspired by the kubernetes client-go, but also allows handling quirks in the engine API
+// in a graceful way, without making quirky APIs incompatible with the generic code in this package or
+// letting the user of this library handle the quirks.
+package api

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,0 +1,133 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+var (
+	// ErrUnidentifiedObject is returned when an IdentifiedObject was required, but the passed object didn't have the identifying attribute set.
+	ErrUnidentifiedObject = errors.New("passed object does not have its identifying attribute set")
+
+	// ErrOperationNotSupported is returned when requesting an operation on a resource it does not support.
+	ErrOperationNotSupported = errors.New("requested operation is not supported by the resource type")
+
+	// ErrUnsupportedResponseFormat is set when the engine responds in a format we don't understand, for example unknown Content-Types.
+	ErrUnsupportedResponseFormat = errors.New("response format is not supported")
+
+	// ErrPageResponseNotSupported is returned when trying to parse a paged response and the format of the response body is not (yet) supported.
+	ErrPageResponseNotSupported = fmt.Errorf("paged response invalid: %w", ErrUnsupportedResponseFormat)
+
+	// ErrCannotListChannelAndPaged is returned when the user List()ing with the AsObjectChannel() and Paged() options set and didn't gave nil for Paged() PageInfo output argument.
+	ErrCannotListChannelAndPaged = errors.New("list with Paged and ObjectChannel is only valid when not retrieving the PageInfo iterator via Paged option")
+
+	// ErrTypeNotSupported is returned when an argument is of type interface{}, manual type checking via reflection is done and the given arguments type cannot be used.
+	ErrTypeNotSupported = errors.New("the given type cannot be used for the requested operation")
+
+	// ErrContextRequired is returned when a nil context was passed as argument.
+	ErrContextRequired = errors.New("no context given")
+)
+
+// EngineError is the base type for all errors returned by the engine.
+//
+// Ideally all errors returned by the API are transformed into EngineErrors, making HTTPError obsolete, as this
+// would completely decouple communicating with the Engine from using HTTP.
+type EngineError struct {
+	message string
+	wrapped error
+}
+
+var (
+	// ErrNotFound is returned when the given identified object does not exist in the engine. Take a look at IgnoreNotFound(), too.
+	ErrNotFound EngineError = EngineError{message: "requested resource does not exist on the engine"}
+
+	// ErrAccessDenied is returned when the used authentication credential is not authorized to do the requested operation.
+	ErrAccessDenied EngineError = EngineError{message: "access to requested resource was denied by the engine"}
+)
+
+// IgnoreNotFound is a helper to handle ErrNotFound differently than other errors with less code.
+func IgnoreNotFound(err error) error {
+	if errors.Is(err, ErrNotFound) {
+		return nil
+	}
+
+	return err
+}
+
+// Error returns the message of the EngineError, implementing the `error` interface.
+func (e EngineError) Error() string {
+	return e.message
+}
+
+// Unwrap returns the wrapped error of the EngineError, making it compatible with `errors.Is/As/Unwrap`.
+func (e EngineError) Unwrap() error {
+	return e.wrapped
+}
+
+// HTTPError is an not-specially-implemented EngineError for a given status code. Ideally this is not used
+// because every returned error is mapped to an ErrSomething package variable, decoupling error handling from
+// the transport protocol.
+type HTTPError struct {
+	message    string
+	wrapped    error
+	statusCode int
+	url        *url.URL
+	method     string
+}
+
+// newHTTPError creates a new HTTP error, taking the information from the given request and response. It
+// can optionally wrap an error and have a custom message.
+func newHTTPError(req *http.Request, res *http.Response, wrapped error, message *string) HTTPError {
+	var msg string
+
+	if message != nil {
+		msg = *message
+	} else {
+		msg = fmt.Sprintf("Engine returned an error: %v (%v)", res.Status, res.StatusCode)
+	}
+
+	e := HTTPError{
+		message:    msg,
+		wrapped:    wrapped,
+		statusCode: res.StatusCode,
+		url:        req.URL,
+		method:     req.Method,
+	}
+
+	return e
+}
+
+// StatusCode returns the HTTP status code of the HTTPError.
+func (e HTTPError) StatusCode() int {
+	return e.statusCode
+}
+
+// Unwrap returns the error which caused this one.
+func (e HTTPError) Unwrap() error {
+	return e.wrapped
+}
+
+// Error returns the error message.
+func (e HTTPError) Error() string {
+	return e.message
+}
+
+func errorFromResponse(req *http.Request, res *http.Response) error {
+	var specificError error
+
+	switch res.StatusCode {
+	case 403:
+		specificError = ErrAccessDenied
+	case 404:
+		specificError = ErrNotFound
+	}
+
+	// We check for higher than 300 because redirects should be handled already
+	if res.StatusCode > 300 || specificError != nil {
+		return newHTTPError(req, res, specificError, nil)
+	}
+
+	return nil
+}

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/lbaas/backend"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func ExampleIgnoreNotFound() {
+	api := newExampleAPI()
+
+	backend := backend.Backend{Identifier: "non-existing identifier"}
+	if err := api.Get(context.TODO(), &backend); IgnoreNotFound(err) != nil {
+		fmt.Printf("Error retrieving backend from engine: %v\n", err)
+	} else if err != nil {
+		fmt.Printf("Requested backend does not exist\n")
+	} else {
+		fmt.Printf("Retrieved backend with name '%v'\n", backend.Name)
+	}
+
+	// Output:
+	// Requested backend does not exist
+}
+
+var _ = Describe("HTTPError", func() {
+	Context("when creating a HTTPError without custom message and without wrapping an error", func() {
+		var err error
+
+		BeforeEach(func() {
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(500)
+
+			err = newHTTPError(req, rec.Result(), nil, nil)
+
+			he := HTTPError{
+				message:    "Engine returned an error: 500 Internal Server Error (500)",
+				statusCode: 500,
+				url: &url.URL{
+					Path: "/",
+				},
+				method: "GET",
+			}
+
+			Expect(err).To(MatchError(he))
+		})
+
+		It("it returns the status code", func() {
+			var he HTTPError
+			Expect(errors.As(err, &he)).To(BeTrue())
+			Expect(he.StatusCode()).To(Equal(500))
+		})
+
+		It("it returns the expected message", func() {
+			var he HTTPError
+			Expect(errors.As(err, &he)).To(BeTrue())
+			Expect(he.Error()).To(Equal("Engine returned an error: 500 Internal Server Error (500)"))
+		})
+
+		It("it does not wrap an EngineError", func() {
+			var ee EngineError
+			Expect(errors.As(err, &ee)).To(BeFalse())
+		})
+	})
+
+	Context("when creating a HTTPError with wrapping an EngineError", func() {
+		var err error
+
+		BeforeEach(func() {
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(500)
+
+			err = newHTTPError(req, rec.Result(), ErrNotFound, nil)
+		})
+
+		It("it wraps the given EngineError error", func() {
+			Expect(err).To(MatchError(ErrNotFound))
+		})
+	})
+
+	Context("when creating a HTTPError with a custom error message", func() {
+		var err error
+
+		BeforeEach(func() {
+			req := httptest.NewRequest("GET", "/", nil)
+			rec := httptest.NewRecorder()
+			rec.WriteHeader(500)
+
+			msg := "Random message for testing"
+			err = newHTTPError(req, rec.Result(), nil, &msg)
+		})
+
+		It("it returns the correct message", func() {
+			Expect(err.Error()).To(Equal("Random message for testing"))
+		})
+	})
+})
+
+var _ = Describe("errorFromResponse function", func() {
+	req := httptest.NewRequest("GET", "/", nil)
+
+	var statusCode int
+	var res *http.Response
+
+	JustBeforeEach(func() {
+		rec := httptest.NewRecorder()
+		rec.WriteHeader(statusCode)
+		res = rec.Result()
+	})
+
+	Context("for status code 404", func() {
+		BeforeEach(func() {
+			statusCode = 404
+		})
+
+		It("returns ErrNotFound as expected", func() {
+			err := errorFromResponse(req, res)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ErrNotFound))
+		})
+	})
+
+	Context("for status code 403", func() {
+		BeforeEach(func() {
+			statusCode = 403
+		})
+
+		It("returns ErrAccessDenied as expected", func() {
+			err := errorFromResponse(req, res)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ErrAccessDenied))
+		})
+	})
+
+	Context("for status code 500", func() {
+		BeforeEach(func() {
+			statusCode = 500
+		})
+
+		It("returns a matching HTTPError as expected", func() {
+			err := errorFromResponse(req, res)
+			Expect(err).To(HaveOccurred())
+
+			var he HTTPError
+			ok := errors.As(err, &he)
+			Expect(ok).To(BeTrue())
+
+			Expect(he.StatusCode()).To(Equal(500))
+		})
+	})
+})
+
+var _ = Describe("EngineError", func() {
+	It("returns the correct message", func() {
+		Expect(ErrNotFound.Error()).To(Equal("requested resource does not exist on the engine"))
+	})
+
+	Context("when created without a wrapping error", func() {
+		It("does not return a wrapped error", func() {
+			Expect(ErrNotFound.Unwrap()).To(BeNil())
+		})
+	})
+})

--- a/pkg/api/internal/options.go
+++ b/pkg/api/internal/options.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+// PagedOption is an option valid for List operations to retrieve objects in a paged fashion (instead of all at once).
+type PagedOption struct {
+	// Page to retrieve
+	Page uint
+
+	// Entries per page
+	Limit uint
+
+	// Additional output about the current page, includes a way to iterate through all pages.
+	Info *types.PageInfo
+}
+
+// ApplyToList applies the Paged option to all the ListOptions.
+func (p PagedOption) ApplyToList(o *types.ListOptions) {
+	o.Paged = true
+	o.Page = p.Page
+	o.EntriesPerPage = p.Limit
+	o.PageInfo = p.Info
+}
+
+// AsObjectChannelOption configures the List operation to return the objects via the given channel.
+type AsObjectChannelOption struct {
+	Channel *types.ObjectChannel
+}
+
+// ApplyToList applies the AsObjectChannel option to all the ListOptions.
+func (aoc AsObjectChannelOption) ApplyToList(o *types.ListOptions) {
+	o.ObjectChannel = aoc.Channel
+}

--- a/pkg/api/mockserver_test.go
+++ b/pkg/api/mockserver_test.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path"
+	"regexp"
+	"strconv"
+
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/anexia-it/go-anxcloud/pkg/lbaas/backend"
+	lbaasCommon "github.com/anexia-it/go-anxcloud/pkg/lbaas/common"
+	"github.com/anexia-it/go-anxcloud/pkg/lbaas/loadbalancer"
+)
+
+func newMockServer() *ghttp.Server {
+	type errorResponseData struct {
+		Message string `json:"message"`
+		Code    int    `json:"code"`
+	}
+
+	type errorResponseType struct {
+		E errorResponseData `json:"error"`
+	}
+
+	errorResponse := func(code int, msg string, res http.ResponseWriter) {
+		res.Header().Add("Content-Type", "application/json; charset=utf-8")
+		res.WriteHeader(code)
+
+		if msg == "" {
+			msg = http.StatusText(code)
+		}
+
+		_ = json.NewEncoder(res).Encode(errorResponseType{
+			E: errorResponseData{
+				Message: msg,
+				Code:    code,
+			},
+		})
+	}
+
+	server := ghttp.NewServer()
+	server.SetAllowUnhandledRequests(true)
+	server.SetUnhandledRequestStatusCode(500)
+
+	backends := []backend.Backend{
+		{
+			Name:       "Example-Backend",
+			Identifier: "bogus identifier 1",
+			Mode:       lbaasCommon.TCP,
+			LoadBalancer: loadbalancer.LoadBalancerInfo{
+				Identifier: "bogus identifier 2",
+			},
+		},
+		{
+			Name:       "backend-01",
+			Identifier: "bogus identifier 3",
+			Mode:       lbaasCommon.TCP,
+		},
+	}
+
+	const backendBasePath = "/api/LBaaS/v1/backend.json"
+	singleBackendPath, _ := regexp.Compile(backendBasePath + "/.*")
+
+	server.RouteToHandler("GET", backendBasePath, func(res http.ResponseWriter, req *http.Request) {
+		var lb_filter *string
+
+		if filters, err := url.ParseQuery(req.URL.Query().Get("filters")); err != nil {
+			errorResponse(500, "invalid filter parameter", res)
+			return
+		} else {
+			if lb := filters.Get("load_balancer"); lb != "" {
+				lb_filter = &lb
+			}
+		}
+
+		page := 1
+		limit := 0
+
+		if p := req.URL.Query().Get("page"); p != "" {
+			if pp, err := strconv.ParseInt(p, 10, 32); err != nil || pp <= 0 {
+				errorResponse(500, "invalid page parameter", res)
+				return
+			} else {
+				page = int(pp)
+			}
+		}
+
+		if l := req.URL.Query().Get("limit"); l != "" {
+			if pl, err := strconv.ParseInt(l, 10, 32); err != nil || pl < 0 {
+				errorResponse(500, "invalid limit parameter", res)
+				return
+			} else {
+				limit = int(pl)
+			}
+		}
+
+		ret := make([]backend.Backend, 0, len(backends))
+
+		for _, b := range backends {
+			if lb_filter == nil || b.LoadBalancer.Identifier == *lb_filter {
+				ret = append(ret, b)
+			}
+		}
+
+		if limit > 0 {
+			idxStart := (page - 1) * limit
+
+			if idxStart >= len(ret) {
+				ret = make([]backend.Backend, 0)
+			} else {
+
+				idxEnd := idxStart + limit
+
+				if idxEnd > len(ret) {
+					idxEnd = len(ret)
+				}
+
+				ret = ret[idxStart:idxEnd]
+			}
+		}
+
+		res.Header().Add("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(res).Encode(ret)
+	})
+
+	identifierGenerateCounter := 1
+
+	server.RouteToHandler("POST", backendBasePath, func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Add("Content-Type", "application/json; charset=utf-8")
+		_ = json.NewEncoder(res).Encode(
+			backend.Backend{
+				Name:       "backend-01",
+				Identifier: "generated identifier " + strconv.Itoa(identifierGenerateCounter),
+				Mode:       lbaasCommon.TCP,
+			},
+		)
+
+		identifierGenerateCounter++
+	})
+
+	server.RouteToHandler("GET", singleBackendPath, func(res http.ResponseWriter, req *http.Request) {
+
+		identifier := path.Base(req.URL.Path)
+
+		for _, b := range backends {
+			if b.Identifier == identifier {
+				res.Header().Add("Content-Type", "application/json; charset=utf-8")
+				_ = json.NewEncoder(res).Encode(b)
+				return
+			}
+		}
+
+		errorResponse(404, "", res)
+	})
+
+	server.RouteToHandler("PUT", singleBackendPath, func(res http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("content-type") != "application/json; charset=utf-8" {
+			errorResponse(505, "Content-Type header on request not set", res)
+			return
+		}
+
+		update := backend.Backend{}
+		if err := json.NewDecoder(req.Body).Decode(&update); err != nil {
+			errorResponse(505, "Invalid request body", res)
+			return
+		}
+
+		identifier := path.Base(req.URL.Path)
+
+		newBackends := make([]backend.Backend, 0, len(backends))
+		found := false
+
+		for _, b := range backends {
+			if b.Identifier == identifier {
+				newBackends = append(newBackends, update)
+				found = true
+			} else {
+				newBackends = append(newBackends, b)
+			}
+		}
+
+		backends = newBackends
+
+		if !found {
+			errorResponse(404, "", res)
+		} else {
+			res.Header().Add("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(res).Encode(update)
+		}
+	})
+
+	server.RouteToHandler("DELETE", singleBackendPath, func(res http.ResponseWriter, req *http.Request) {
+		identifier := path.Base(req.URL.Path)
+
+		newBackends := make([]backend.Backend, 0, len(backends))
+
+		found := false
+		for _, b := range backends {
+			if b.Identifier != identifier {
+				newBackends = append(newBackends, b)
+			} else {
+				found = true
+			}
+		}
+
+		backends = newBackends
+
+		if !found {
+			errorResponse(404, "", res)
+		} else {
+			res.Header().Add("Content-Type", "application/json; charset=utf-8")
+			_ = json.NewEncoder(res).Encode(map[string]interface{}{})
+		}
+	})
+
+	return server
+}

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+func getObjectIdentifier(obj types.Object, singleObjectOperation bool) (string, error) {
+	objectType := reflect.TypeOf(obj)
+
+	if objectType.Kind() != reflect.Ptr {
+		return "", fmt.Errorf("%w: the Object interface must be implemented on a pointer to struct", ErrTypeNotSupported)
+	} else if objectType.Elem().Kind() != reflect.Struct {
+		return "", fmt.Errorf("%w: Objects must be implemented as structs", ErrTypeNotSupported)
+	}
+
+	objectStructType := objectType.Elem()
+	numFields := objectStructType.NumField()
+
+	for i := 0; i < numFields; i++ {
+		field := objectStructType.Field(i)
+
+		if val, ok := field.Tag.Lookup("anxcloud"); ok {
+			if val == "identifier" {
+				identifierValue := reflect.ValueOf(obj).Elem().Field(i)
+
+				// We check on the value to have a type-independent zero check, in case we later allow other
+				// types for identifier. A int identifier is zero with value 0, which encoded to string "0",
+				// so a later identifier == "" check would not work.
+				if singleObjectOperation && identifierValue.IsZero() {
+					return "", ErrUnidentifiedObject
+				}
+
+				// TODO: maybe we need to support other types, too - any scalar, string-convertable type should do just fine
+				switch identifierValue.Kind() {
+				case reflect.String:
+					return identifierValue.String(), nil
+				default:
+					return "", fmt.Errorf("%w: Objects identifier field has an unsupported type (type %v has an identifier of type %v)", ErrTypeNotSupported, objectStructType, field.Type)
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("%w: Object lacks identifier field (type %v does not have a field with `anxcloud:\"identifier\"` tag)", ErrTypeNotSupported, objectStructType)
+}

--- a/pkg/api/object_example_test.go
+++ b/pkg/api/object_example_test.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+
+	// the following are for testing only, you don't need them
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+)
+
+// ExampleObject is an API Object we define as example how to make something an Object.
+//
+// Objects must have tags for json encoding/decoding and exactly one must be tagged as anxcloud:"identifier".
+type ExampleObject struct {
+	Identifier string `json:"identifier" anxcloud:"identifier"`
+	Name       string `json:"name"`
+}
+
+// This is the most-basic implementation for EndpointURL, only returning the URL. This is the case for resources
+// that support all operations and have the default URL mapping:
+// * Create:  POST    url
+// * List:    GET     url
+// * Get:     GET     url/identifier
+// * Update:  PUT     url/identifier
+// * Destroy: DELETE  url/identifier
+//
+// Some objects don't support all operations, you'd then have to check the passed `op`eration and return
+// ErrOperationNotSupported for unsupported operations.
+//
+// Sometimes URLs for Objects done match this schema. As long as the last part of the URL is the identifier for
+// operations on specific objects, you can switch-case on the operation and return the correct URLs. The
+// identifier is appended by default for Get, Update and Destroy operations. You can implement the interface
+// types.RequestFilterHook to have full control over the requests done for your object.
+func (o *ExampleObject) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
+	return url.Parse("/example/v1")
+}
+
+// This is a more complex example, supporting to List with a filter
+type ExampleFilterableObject struct {
+	Identifier string `json:"identifier" anxcloud:"identifier"`
+	Name       string `json:"name"`
+	Mode       string `json:"mode"`
+}
+
+// This is an example for the EndpointURL method for an Object that can use a filter for List operations.
+//
+// The API in this case expects a query argument called `filter` with a URL-encoded query string in it,
+// so for filtering for name=foo and mode=tcp the full URL might look like this:
+// `/filter_example/v1?filter=name%3Dfoo%26mode%3Dtcp`.
+func (o *ExampleFilterableObject) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
+	// we can ignore the error since the URL is hard-coded known as valid
+	u, _ := url.Parse("/filter_example/v1")
+
+	if op == types.OperationList {
+		filter := url.Values{}
+
+		if o.Name != "" {
+			filter.Add("name", o.Name)
+		}
+
+		if o.Mode != "" {
+			filter.Add("mode", o.Mode)
+		}
+
+		if filters := filter.Encode(); filters != "" {
+			query := u.Query()
+			query.Add("filter", filters)
+			u.RawQuery = query.Encode()
+		}
+	}
+
+	return u, nil
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+// code below is not part of this example but makes it appear in the docs at all and uses it as test. //
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+type ExampleObjectMockHandler struct {
+	filtered []ExampleFilterableObject
+}
+
+func (h *ExampleObjectMockHandler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	res.Header().Add("Content-Type", "application/json; charset=utf-8")
+
+	switch req.URL.Path {
+	case "/example/v1":
+		d := json.NewDecoder(req.Body)
+		d.DisallowUnknownFields()
+
+		o := ExampleObject{}
+		_ = d.Decode(&o)
+
+		o.Identifier = "some random identifier"
+		_ = json.NewEncoder(res).Encode(o)
+	case "/filter_example/v1":
+		if page := req.URL.Query().Get("page"); page != "1" && page != "" {
+			break
+		}
+
+		nameFilter := ""
+		modeFilter := ""
+
+		if f := req.URL.Query().Get("filter"); f != "" {
+			filters, _ := url.ParseQuery(f)
+
+			nameFilter = filters.Get("name")
+			modeFilter = filters.Get("mode")
+		}
+
+		ret := make([]ExampleFilterableObject, 0, len(h.filtered))
+
+		for _, o := range h.filtered {
+			ok := true
+
+			if nameFilter != "" && o.Name != nameFilter {
+				ok = false
+			}
+
+			if modeFilter != "" && o.Mode != modeFilter {
+				ok = false
+			}
+
+			if ok {
+				ret = append(ret, o)
+			}
+		}
+
+		_ = json.NewEncoder(res).Encode(ret)
+	}
+}
+
+func Example_implementObject() {
+	mock := ExampleObjectMockHandler{
+		filtered: []ExampleFilterableObject{
+			{Name: "hello TCP 1", Mode: "tcp", Identifier: "random identifier 1"},
+			{Name: "hello UDP 1", Mode: "udp", Identifier: "random identifier 2"},
+			{Name: "hello TCP 2", Mode: "tcp", Identifier: "random identifier 3"},
+			{Name: "hello UDP 2", Mode: "udp", Identifier: "random identifier 4"},
+		},
+	}
+
+	server := httptest.NewServer(&mock)
+
+	api, err := NewAPI(
+		WithClientOptions(
+			client.IgnoreMissingToken(),
+			client.BaseURL(server.URL),
+		),
+	)
+
+	if err != nil {
+		fmt.Printf("Error creating API instance: %v\n", err)
+		return
+	}
+
+	ctx := context.TODO()
+
+	// trying to create an ExampleObject on the API
+	o := ExampleObject{Name: "hello world"}
+	if err := api.Create(ctx, &o); err != nil {
+		fmt.Printf("Error creating object on API: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Object created, identifier '%v'\n", o.Identifier)
+
+	// trying to list ExampleFilterableObjects on the API, filtered on mode=tcp
+	fo := ExampleFilterableObject{Mode: "tcp"}
+	var fopi types.PageInfo
+	if err := api.List(ctx, &fo, Paged(1, 1, &fopi)); err != nil {
+		fmt.Printf("Error listing objects on API: %v\n", err)
+		return
+	}
+
+	var fos []ExampleFilterableObject
+	for fopi.Next(&fos) {
+		for _, fo := range fos {
+			fmt.Printf("Retrieved object with mode '%v' named '%v'\n", fo.Mode, fo.Name)
+		}
+	}
+
+	// Output:
+	// Object created, identifier 'some random identifier'
+	// Retrieved object with mode 'tcp' named 'hello TCP 1'
+	// Retrieved object with mode 'tcp' named 'hello TCP 2'
+}

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"github.com/anexia-it/go-anxcloud/pkg/api/internal"
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+// AsObjectChannel configures the List operation to return the objects via the given channel.
+func AsObjectChannel(channel *types.ObjectChannel) ListOption {
+	return internal.AsObjectChannelOption{Channel: channel}
+}
+
+// Paged is an option valid for List operations to retrieve objects in a paged fashion (instead of all at once).
+func Paged(page, limit uint, info *types.PageInfo) ListOption {
+	return internal.PagedOption{
+		Page:  page,
+		Limit: limit,
+		Info:  info,
+	}
+}

--- a/pkg/api/pagination.go
+++ b/pkg/api/pagination.go
@@ -1,0 +1,252 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+	"github.com/go-logr/logr"
+)
+
+// maxPageFetchRetry is the maximum number of retries to fetch a single page.
+// When that retry count is reached, an error is set that cannot be cleared with ResetError().
+const maxPageFetchRetry = 10
+
+type pageFetcher func(page uint) (json.RawMessage, error)
+
+type pageIter struct {
+	currentPage  uint
+	totalPages   uint
+	totalItems   uint
+	itemsPerPage uint
+
+	err             error
+	errRetryCounter uint
+
+	pageFetcher pageFetcher
+
+	ctx context.Context
+}
+
+// CurrentPage returns the page number the last Next call processed.
+func (p *pageIter) CurrentPage() uint {
+	return p.currentPage
+}
+
+// TotalPages returns the total number of pages. Note: not all APIs support this and will then return 0.
+func (p *pageIter) TotalPages() uint {
+	return p.totalPages
+}
+
+// TotalItems returns the total number of items. Note: not all APIs support this and will then return 0.
+func (p *pageIter) TotalItems() uint {
+	return p.totalItems
+}
+
+// ItemsPerPage returns the maximum number of entries per page, corresponding to the Limit parameter given
+// to the Paged attribute.
+func (p *pageIter) ItemsPerPage() uint {
+	return p.itemsPerPage
+}
+
+// Next retrieves the next page of objects to process. On the first call, it gives the exact same
+// objects as api.List() returned to allow iterating over all pages easily. It returns true when it
+// has received another page of objects and false on completion or error. Errors can be retrieved by
+// calling PageInfo.Error().
+func (p *pageIter) Next(objects interface{}) bool {
+	if p.err != nil {
+		return false
+	}
+
+	val := reflect.ValueOf(objects)
+
+	isPointer := val.Kind() == reflect.Ptr
+	isArrayOrSlice := false
+	isObjects := false
+	isRawMessages := false
+
+	wrongType := val.Type()
+
+	if isPointer {
+		kind := val.Elem().Kind()
+		isArrayOrSlice = kind == reflect.Slice || kind == reflect.Array
+	}
+
+	if isArrayOrSlice {
+		objectType := reflect.TypeOf((*types.Object)(nil)).Elem()
+
+		elementType := val.Elem().Type().Elem()
+		ptrToElementType := reflect.PtrTo(elementType)
+
+		isObjects = elementType.Implements(objectType) || ptrToElementType.Implements(objectType)
+		isRawMessages = elementType == reflect.TypeOf((*json.RawMessage)(nil)).Elem()
+	}
+
+	// the check for isObjects || isRawMessages isn't actually required, but is kept to prevent users decoding their
+	// page of objects into something completely different by accident. I currently don't see a valid reason to do
+	// that, but if one comes up, this can probably be removed. -- Mara @LittleFox94 Grosch, 2021-10-16
+	// json.RawMessage is allowed for retrieving objects via channel, where the page is decoded into an array of
+	// json.RawMessage and every entry of that is decoded into the target object as soon as it is needed.
+	if !isPointer || !isArrayOrSlice || (!isObjects && !isRawMessages) {
+		p.err = fmt.Errorf("%w: the argument given to PageInfo.Next() must be a pointer to []T where T or *T implements types.Object or T is json.RawMessage; expected *[]T, you gave %v", ErrTypeNotSupported, wrongType)
+		return false
+	}
+
+	p.currentPage++
+
+	pageData, err := p.pageFetcher(p.currentPage)
+	if err != nil {
+		p.errRetryCounter++
+		p.err = err
+		return false
+	}
+
+	_, _, _, _, data, err := decodePaginationResponseBody(pageData, types.ListOptions{Page: p.currentPage, EntriesPerPage: p.itemsPerPage})
+	if err != nil {
+		p.errRetryCounter++
+		p.err = err
+		return false
+	}
+
+	d := json.NewDecoder(bytes.NewBuffer(data))
+	d.DisallowUnknownFields()
+
+	if err := d.Decode(objects); err != nil {
+		p.errRetryCounter++
+		p.err = err
+		return false
+	}
+
+	log := logr.FromContextOrDiscard(p.ctx)
+
+	retrievedElements := uint(val.Elem().Len())
+	if retrievedElements > p.itemsPerPage && p.itemsPerPage > 0 {
+		log.Info("Retrieved more elements in one Next() than wanted", "wanted", p.itemsPerPage, "retrieved", retrievedElements)
+	} else {
+		log.V(1).Info("Retrieved elements from engine", "limit", p.itemsPerPage, "retrieved", retrievedElements)
+	}
+
+	p.errRetryCounter = 0
+
+	return retrievedElements > 0
+}
+
+// Returns error. An iteration over all pages has successfully completed when Next() returns false and
+// Error() returns nil. You should check for errors after Next() returns false to differentiate between
+// "all pages done" and "error retrieving page".
+func (p *pageIter) Error() error {
+	return p.err
+}
+
+// ResetError clears any stored error to resume the iterator. If the retry counter for the current page exceeded
+// a package-defined maximum, the error cannot be cleared and Error() will return it after ResetError() was called.
+// you have to check for this.
+func (p *pageIter) ResetError() {
+	if p.errRetryCounter < maxPageFetchRetry {
+		p.currentPage--
+		p.err = nil
+	}
+}
+
+func newPageIter(ctx context.Context, responseBody json.RawMessage, opts types.ListOptions, fetcher pageFetcher) (types.PageInfo, error) {
+	if logger, err := logr.FromContext(ctx); err == nil {
+		ctx = logr.NewContext(ctx, logger.WithName("pagination"))
+	}
+
+	ret := pageIter{
+		ctx: ctx,
+	}
+
+	currentPage, limit, totalPages, totalItems, data, err := decodePaginationResponseBody(responseBody, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	ret.currentPage = currentPage
+	ret.itemsPerPage = limit
+	ret.totalPages = totalPages
+	ret.totalItems = totalItems
+
+	// first pageFetcher is returning the data we got with the initial request, after this is fetched, we
+	// use the pageFetcher provided as argument
+	ret.pageFetcher = func(page uint) (json.RawMessage, error) {
+		ret.pageFetcher = fetcher
+		return data, nil
+	}
+
+	return &ret, nil
+}
+
+func decodePaginationResponseBody(data json.RawMessage, opts types.ListOptions) (page, limit, totalPages, totalItems uint, ret json.RawMessage, err error) {
+	page = 0
+	limit = 0
+	totalPages = 0
+	totalItems = 0
+	ret = json.RawMessage{}
+
+	// TODO(LittleFox94): this is not the same for every API and we need a way to override this or
+	// find the X ways it's done and have options for that. Currently we support those two types and
+	// "plain data array".
+
+	type dataResponse struct {
+		CurrentPage    uint `json:"page"`
+		TotalPages     uint `json:"total_pages"`
+		TotalItems     uint `json:"total_items"`
+		EntriesPerPage uint `json:"limit"`
+
+		Data json.RawMessage `json:"data"`
+	}
+
+	type dataDataResponse struct {
+		State    string       `json:"state"`
+		Messages []string     `json:"messages"`
+		Data     dataResponse `json:"data"`
+	}
+
+	// First dataData then data is important since we switch over the index of the decoded message,
+	// set data from dataData and fallthrough.
+	// The entries have to be pointers, else every entry matches every data - since it is an interface{} then.
+	responseTypes := []interface{}{&dataDataResponse{}, &dataResponse{}, &[]json.RawMessage{}}
+	actualResponse := -1
+
+	for i, response := range responseTypes {
+		decoder := json.NewDecoder(bytes.NewBuffer(data))
+
+		// in case we receive a completely different response we have to prevent it being decodable into one
+		// of the supported formats by accident.
+		decoder.DisallowUnknownFields()
+
+		if err := decoder.Decode(&response); err == nil {
+			actualResponse = i
+			break
+		}
+	}
+
+	if actualResponse == -1 {
+		err = ErrPageResponseNotSupported
+		return
+	}
+
+	switch actualResponse {
+	case 0:
+		responseTypes[1] = &responseTypes[0].(*dataDataResponse).Data
+		fallthrough
+	case 1:
+		data := responseTypes[1].(*dataResponse)
+		page = data.CurrentPage - 1 // Next increments the page before trying to retrieve it
+		limit = data.EntriesPerPage
+		totalPages = data.TotalPages
+		totalItems = data.TotalItems
+		ret = data.Data
+	case 2:
+		page = opts.Page
+		limit = opts.EntriesPerPage
+
+		ret, err = json.Marshal(responseTypes[2])
+	}
+
+	return page, limit, totalPages, totalItems, ret, err
+}

--- a/pkg/api/pagination_test.go
+++ b/pkg/api/pagination_test.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type pagination_test_object struct {
+	Message string `json:"message"`
+}
+
+func (p pagination_test_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return nil, ErrOperationNotSupported
+}
+
+var _ = Describe("PageInfo implementation pageIter", func() {
+	var responses []json.RawMessage
+	var afterErrorResponse json.RawMessage
+
+	var pi types.PageInfo
+	var piCreateError error
+
+	JustBeforeEach(func() {
+		returnedErrors := 0
+
+		fetcher := func(page uint) (json.RawMessage, error) {
+			if page > uint(len(responses)) {
+				return json.RawMessage("[]"), nil
+			}
+
+			if responses[page-1] == nil {
+				returnedErrors++
+
+				switch returnedErrors {
+				case 1:
+					return nil, HTTPError{statusCode: 500, message: "Server error"}
+				case 2:
+					return json.RawMessage(`-öasjfn.ksdjfbksdnmf, sdf`), nil
+				case 3:
+					return json.RawMessage(`[{ "error": "random garbage data returned" }]`), nil
+				case 4:
+					return afterErrorResponse, nil
+				}
+			}
+
+			return responses[page-1], nil
+		}
+
+		var responseBody json.RawMessage = nil
+
+		if len(responses) > 0 {
+			responseBody = responses[0]
+		}
+
+		opts := types.ListOptions{
+			EntriesPerPage: 2,
+		}
+
+		pi, piCreateError = newPageIter(context.TODO(), responseBody, opts, fetcher)
+	})
+
+	AssertCommonBehavior := func() {
+		It("creates the iterator without error", func() {
+			Expect(piCreateError).NotTo(HaveOccurred())
+		})
+
+		It("barks when argument given to Next is not as expected", func() {
+			var out []string
+			ok := pi.Next(&out)
+			err := pi.Error()
+
+			Expect(ok).To(BeFalse())
+			Expect(err).To(MatchError(ErrTypeNotSupported))
+		})
+
+		It("iterates through the pages until first error", func() {
+			var out []json.RawMessage
+
+			expectedPage := 1
+			var page uint
+			for pi.Next(&out) {
+				page = pi.CurrentPage()
+				Expect(page).To(BeEquivalentTo(expectedPage))
+				expectedPage++
+			}
+
+			Expect(page).To(BeEquivalentTo(1))
+			Expect(pi.CurrentPage()).To(BeEquivalentTo(2))
+
+			// This is the data of the first page. With the fetcher returning an error, this data
+			// is not overwritten even though we already are on second page. We can use this behavior
+			// for testing, but since it's not obvious, there is a comment here :)
+			Expect(out).To(HaveLen(3))
+
+			err := pi.Error()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Server error"))
+		})
+
+		It("continues after error is cleared", func() {
+			ok := true
+
+			expectedPage := 1
+			expectedError := 0
+
+			for ok {
+				var out []pagination_test_object
+				ok = pi.Next(&out)
+
+				if err := pi.Error(); !ok && err != nil {
+					expectedError++
+
+					switch expectedError {
+					case 1:
+						Expect(err.Error()).To(ContainSubstring("Server error"))
+					case 2:
+						Expect(err).To(MatchError(ErrPageResponseNotSupported))
+					case 3:
+						Expect(err.Error()).To(ContainSubstring("unknown field \"error\""))
+					}
+
+					Expect(pi.Next(&out)).To(BeFalse())
+
+					pi.ResetError()
+					ok = pi.Error() == nil
+					continue
+				}
+
+				Expect(pi.CurrentPage()).To(BeEquivalentTo(expectedPage))
+				expectedPage++
+			}
+
+			Expect(pi.Error()).NotTo(HaveOccurred())
+			Expect(expectedError).To(Equal(3))
+		})
+	}
+
+	// Just a plain json array with the results is returned.
+	Context("with raw-array pages", func() {
+		BeforeEach(func() {
+			responses = []json.RawMessage{
+				json.RawMessage(`[ { "message": "foo" }, { "message": "bar" }, { "message": "why not give one more than limit? :o)" } ]`),
+				nil,
+				json.RawMessage(`[ { "message": "baz" } ]`),
+			}
+
+			afterErrorResponse = json.RawMessage(`[ { "message": "server ok again" } ]`)
+		})
+
+		It("returns 0 for TotalPages and TotalItems and 2 for ItemsPerPage", func() {
+			Expect(pi.TotalPages()).To(BeEquivalentTo(0))
+			Expect(pi.TotalItems()).To(BeEquivalentTo(0))
+			Expect(pi.ItemsPerPage()).To(BeEquivalentTo(2))
+		})
+
+		AssertCommonBehavior()
+	})
+
+	// A json object containing the current page, total page and item counts and a data array is returned.
+	Context("with metadata page responses", func() {
+		BeforeEach(func() {
+			responses = []json.RawMessage{
+				json.RawMessage(`{ "page": 1, "total_pages": 3, "total_items": 4, "limit": 2, "data": [ { "message": "foo" }, { "message": "bar" }, { "message": "why not give one more than limit? :o)" } ] }`),
+				nil,
+				json.RawMessage(`{ "page": 3, "total_pages": 3, "total_items": 4, "limit": 2, "data": [ { "message": "baz" } ] }`),
+			}
+
+			afterErrorResponse = json.RawMessage(`{ "page": 2, "total_pages": 3, "total_items": 4, "limit": 2, "data": [ { "message": "server ok again" } ] }`)
+		})
+
+		It("returns correct values for TotalPages, TotalItems and ItemsPerPage", func() {
+			Expect(pi.TotalPages()).To(BeEquivalentTo(3))
+			Expect(pi.TotalItems()).To(BeEquivalentTo(4))
+			Expect(pi.ItemsPerPage()).To(BeEquivalentTo(2))
+		})
+
+		AssertCommonBehavior()
+	})
+
+	// A json object containing "state", a "messages" array and a "data" object containing the current page, total page and item counts and a data array is returned.
+	// Since the actual data is at `data.data` we call this data.data response from now on.
+	Context("with data.data page responses", func() {
+		BeforeEach(func() {
+			responses = []json.RawMessage{
+				json.RawMessage(`{ "state": "success", "messages": [], "data": { "page": 1, "total_pages": 3, "total_items": 4, "limit": 2, "data": [ { "message": "foo" }, { "message": "bar" }, { "message": "why not give one more than limit? :o)" } ] } }`),
+				nil,
+				json.RawMessage(`{ "state": "success", "messages": [], "data": { "page": 3, "total_pages": 3, "total_items": 4, "limit": 2, "data": [ { "message": "baz" } ] } }`),
+			}
+
+			afterErrorResponse = json.RawMessage(`{ "state": "success", "messages": [], "data": { "page": 2, "total_pages": 3, "total_items": 4, "limit": 2, "data": [ { "message": "server ok again" } ] } }`)
+		})
+
+		It("returns correct values for TotalPages, TotalItems and ItemsPerPage", func() {
+			Expect(pi.TotalPages()).To(BeEquivalentTo(3))
+			Expect(pi.TotalItems()).To(BeEquivalentTo(4))
+			Expect(pi.ItemsPerPage()).To(BeEquivalentTo(2))
+		})
+
+		AssertCommonBehavior()
+	})
+
+	Context("with unknown page response format", func() {
+		BeforeEach(func() {
+			responses = []json.RawMessage{
+				json.RawMessage(`{ "alien_pages": 42, "alien_data": [] }`),
+			}
+		})
+
+		It("returns an error on creating the iterator", func() {
+			Expect(piCreateError).To(MatchError(ErrPageResponseNotSupported))
+		})
+	})
+})

--- a/pkg/api/reexport.go
+++ b/pkg/api/reexport.go
@@ -1,0 +1,11 @@
+package api
+
+import "github.com/anexia-it/go-anxcloud/pkg/api/types"
+
+// We re-export them here to group options given by this package under their options in the docs.
+
+type ListOption = types.ListOption
+type GetOption = types.GetOption
+type CreateOption = types.CreateOption
+type UpdateOption = types.UpdateOption
+type DestroyOption = types.DestroyOption

--- a/pkg/api/types/object.go
+++ b/pkg/api/types/object.go
@@ -1,0 +1,44 @@
+package types
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Object is the interface all objects to be retrieved by the generic API client are required to implement.
+//
+// On top of implementing this interface, an Object is always implemented as a struct, the pointer to it is what is passed to the generic API client.
+// These Object structs need to have a string member with `anxcloud:"identifier"` tag on it.
+type Object interface {
+	// Returns the URL to retrieve resources of the given type from or an error.
+	// The request URL is formed of `client.BaseURL() + first return value of this function`, requests for a single object get
+	// the object identifier appended to the path, a / added as needed. APIs using other URL schemes need to implement RequestFilterHook.
+	EndpointURL(ctx context.Context, op Operation, options Options) (*url.URL, error)
+}
+
+// IdentifiedObject is the same as Object and is intended as a doc-helper. Objects are IdentifiedObjects when their
+// identifying attribute (commonly something like "Identifier") is set.
+type IdentifiedObject Object
+
+// FilterObject is the same as Object and is intended as a doc-helper, telling the user only it's type and it implementing an interface is important for the generic API client.
+// Some of the attributes on this Object can be used for filtering or searching, depending on the specific API.
+type FilterObject Object
+
+// RequestFilterHook is an interface Objects can optionally implement to modify requests before they are sent to the engine.
+type RequestFilterHook interface {
+	// FilterAPIRequest is called for every API request involving this object. Instead of the original request, the one returned from this function is sent to the engine.
+	FilterAPIRequest(op Operation, options Options, req *http.Request) (*http.Request, error)
+}
+
+// RequestBodyHook is an interface Objects can optionally implement to customize request bodies based on the object given by the user of this library.
+type RequestBodyHook interface {
+	// FilterAPIRequestBody returns the object to be sent as request body. Not implementing this interface is equivalent to returning the received object from this function.
+	FilterAPIRequestBody(op Operation, options Options) (interface{}, error)
+}
+
+// ResponseFilterHook is an interface Objects can optionally implement to modify response given by the engine before they are decoded.
+type ResponseFilterHook interface {
+	// FilterAPIResponse is called after a response from the engine regarding this object is received. Instead of the original response, the one returned by this function is decoded.
+	FilterAPIResponse(op Operation, options Options, res *http.Response) (*http.Response, error)
+}

--- a/pkg/api/types/operation.go
+++ b/pkg/api/types/operation.go
@@ -1,0 +1,54 @@
+package types
+
+// Operation to do on the engine with an object. Users are expected to compare values
+// of this type to the Operation(Get|Create|...) constants in this package.
+type Operation string
+
+const (
+	// OperationGet is used to retrieve the given identified object from the engine.
+	OperationGet Operation = "Get"
+
+	// OperationCreate is used to create the given object on the engine.
+	OperationCreate Operation = "Create"
+
+	// OperationUpdate is used to update the given identified object on the engine with the newly given data.
+	OperationUpdate Operation = "Update"
+
+	// OperationDestroy is used to destroy the identified object from the engine.
+	OperationDestroy Operation = "Destroy"
+
+	// OperationList is used to retrieve objects with attributes matching the ones in the given object from
+	// the engine.
+	OperationList Operation = "List"
+)
+
+// GetOptions contains options valid for Get operations.
+type GetOptions struct {
+	commonOptions
+}
+
+// ListOptions contains options valid for List operations.
+type ListOptions struct {
+	commonOptions
+	ObjectChannel *ObjectChannel
+
+	Paged          bool
+	Page           uint
+	EntriesPerPage uint
+	PageInfo       *PageInfo
+}
+
+// CreateOptions contains options valid for Create operations.
+type CreateOptions struct {
+	commonOptions
+}
+
+// UpdateOptions contains options valid for Update operations.
+type UpdateOptions struct {
+	commonOptions
+}
+
+// DestroyOptions contains options valid for Destroy operations.
+type DestroyOptions struct {
+	commonOptions
+}

--- a/pkg/api/types/options.go
+++ b/pkg/api/types/options.go
@@ -1,0 +1,75 @@
+package types
+
+import "errors"
+
+var (
+	// ErrKeyNotSet is returned when trying to options.Get(key) a key that is not set.
+	ErrKeyNotSet = errors.New("requested key not set on the given Options")
+
+	// ErrKeyAlreadySet is returned when trying to options.Set(key, v, false) and the key that is already set.
+	ErrKeyAlreadySet = errors.New("given key is already set on the given Options")
+)
+
+type commonOptions struct {
+	additional map[string]interface{}
+}
+
+// Options is the interface all operation-specific options implement, making it possible to pass all the specific options to the same functions.
+// Specific APIs can use this interface to set additional options, keys should be prefixed with the name of the API. This might be enforced in the future.
+type Options interface {
+	Get(key string) (interface{}, error)
+	Set(key string, value interface{}, overwrite bool) error
+}
+
+// GetOption is the interface options have to implement to be usable with Get operation.
+type GetOption interface {
+	// Apply this option to the set of all options
+	ApplyToGet(*GetOptions)
+}
+
+// ListOption is the interface options have to implement to be usable with List operation.
+type ListOption interface {
+	// Apply this option to the set of all options
+	ApplyToList(*ListOptions)
+}
+
+// CreateOption is the interface options have to implement to be usable with Create operation.
+type CreateOption interface {
+	// Apply this option to the set of all options
+	ApplyToCreate(*CreateOptions)
+}
+
+// UpdateOption is the interface options have to implement to be usable with Update operation.
+type UpdateOption interface {
+	// Apply this option to the set of all options
+	ApplyToUpdate(*UpdateOptions)
+}
+
+// DestroyOption is the interface options have to implement to be usable with Destroy operation.
+type DestroyOption interface {
+	// Apply this option to the set of all options
+	ApplyToDestroy(*DestroyOptions)
+}
+
+func (o commonOptions) Get(key string) (interface{}, error) {
+	if o.additional != nil {
+		if v, ok := o.additional[key]; ok {
+			return v, nil
+		}
+	}
+
+	return nil, ErrKeyNotSet
+}
+
+func (o *commonOptions) Set(key string, val interface{}, overwrite bool) error {
+	if o.additional == nil {
+		o.additional = make(map[string]interface{}, 1)
+	}
+
+	if _, alreadySet := o.additional[key]; alreadySet && !overwrite {
+		return ErrKeyAlreadySet
+	}
+
+	o.additional[key] = val
+	return nil
+}

--- a/pkg/api/types/options_test.go
+++ b/pkg/api/types/options_test.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Options type", func() {
+	var options []Options
+
+	BeforeEach(func() {
+		options = []Options{
+			&GetOptions{},
+			&ListOptions{},
+			&CreateOptions{},
+			&DestroyOptions{},
+			&UpdateOptions{},
+		}
+	})
+
+	It("can set additional options from all operation specific option types", func() {
+		for i, opts := range options {
+			err := opts.Set("test", i, false)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	It("barks when setting additional keys twice without overwrite set", func() {
+		for i, opts := range options {
+			err := opts.Set("test", i, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = opts.Set("test", i, false)
+			Expect(err).To(MatchError(ErrKeyAlreadySet))
+		}
+	})
+
+	It("does not bark when setting additional keys twice with overwrite set", func() {
+		for i, opts := range options {
+			err := opts.Set("test", i, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = opts.Set("test", i, true)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+
+	It("barks when retrieving a not-set key", func() {
+		for _, opts := range options {
+			val, err := opts.Get("test")
+			Expect(err).To(MatchError(ErrKeyNotSet))
+			Expect(val).To(BeNil())
+		}
+	})
+
+	It("does not bark when retrieving an additional key that was set before", func() {
+		for i, opts := range options {
+			err := opts.Set("test", i, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			val, err := opts.Get("test")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal(i))
+		}
+	})
+})
+
+func TestAPIUnits(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "test suite for pkg/api/types")
+}

--- a/pkg/api/types/pagination.go
+++ b/pkg/api/types/pagination.go
@@ -1,0 +1,28 @@
+package types
+
+// PageInfo contains information about the currently retrieved page and also a way to
+// iterate over this and following pages.
+type PageInfo interface {
+	// CurrentPage returns the 1-based number of the last page processed in Next.
+	CurrentPage() uint
+
+	// TotalPages returns the total number of pages if supported by the given API, 0 otherwise.
+	TotalPages() uint
+
+	// TotalItems returns the total number of items if supported by the given API, 0 otherwise.
+	TotalItems() uint
+
+	// ItemsPerPage returns the desired number of items retrieved per page from the Engine.
+	ItemsPerPage() uint
+
+	// Next retrieves the data for the next page and stores the decoded values in the given pointer
+	// to array of Object or json.RawMessage.
+	Next(objects interface{}) bool
+
+	// Error returns the error preventing Next to continue.
+	Error() error
+
+	// ResetError can be used to clear errors, making Next able to continue. Some errors cannot be
+	// cleared and Error will still return them after ResetError, you have to check this.
+	ResetError()
+}

--- a/pkg/api/types/types.go
+++ b/pkg/api/types/types.go
@@ -1,0 +1,9 @@
+// Package types contains everything needed by APIs implementing the interfaces to be compatible with the
+// generic API client.
+package types
+
+// ObjectReturner retrieves an object, parsing it to the correct go type.
+type ObjectReturner func(Object) error
+
+// ObjectChannel streams objects.
+type ObjectChannel chan ObjectReturner

--- a/pkg/lbaas/backend/api.go
+++ b/pkg/lbaas/backend/api.go
@@ -2,6 +2,9 @@ package backend
 
 import (
 	"context"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/anexia-it/go-anxcloud/pkg/pagination"
 )
@@ -22,4 +25,42 @@ type api struct {
 // NewAPI creates a new load balancer backend API instance with the given client.
 func NewAPI(c client.Client) API {
 	return &api{c}
+}
+
+// EndpointURL returns the URL where to retrieve objects of type Backend and the identifier of the given Backend.
+// It implements the api.Object interface on *Backend, making it usable with the generic API client.
+func (b *Backend) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
+	u, err := url.ParseRequestURI("/api/LBaaS/v1/backend.json")
+
+	if op == types.OperationList {
+		filters := make(url.Values)
+
+		if b.LoadBalancer.Identifier != "" {
+			filters.Add("load_balancer", b.LoadBalancer.Identifier)
+		}
+
+		if b.Mode != "" {
+			filters.Add("mode", string(b.Mode))
+		}
+
+		query := u.Query()
+		query.Add("filters", filters.Encode())
+		u.RawQuery = query.Encode()
+	}
+
+	return u, err
+}
+
+// FilterAPIRequestBody generates the request body for creating a new Backend, which differs from the Backend object.
+func (b *Backend) FilterAPIRequestBody(op types.Operation, options types.Options) (interface{}, error) {
+	if op == types.OperationCreate {
+		return map[string]string{
+			"name":          b.Name,
+			"load_balancer": b.LoadBalancer.Identifier,
+			"mode":          string(b.Mode),
+			"state":         "4", // "newly created"
+		}, nil
+	}
+
+	return b, nil
 }

--- a/pkg/lbaas/backend/backend.go
+++ b/pkg/lbaas/backend/backend.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/common"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/loadbalancer"
 	"net/http"
 	"net/url"
 	utils "path"
 	"strconv"
+
+	"github.com/anexia-it/go-anxcloud/pkg/lbaas/common"
+	"github.com/anexia-it/go-anxcloud/pkg/lbaas/loadbalancer"
 )
 
 const (
@@ -19,14 +20,14 @@ const (
 
 // BackendInfo holds the identifier and the name of a load balancer backend.
 type BackendInfo struct {
-	Identifier string `json:"identifier"`
+	Identifier string `json:"identifier" anxcloud:"identifier"`
 	Name       string `json:"name"`
 }
 
 type Backend struct {
 	CustomerIdentifier string                        `json:"customer_identifier"`
 	ResellerIdentifier string                        `json:"reseller_identifier"`
-	Identifier         string                        `json:"identifier"`
+	Identifier         string                        `json:"identifier" anxcloud:"identifier"`
 	Name               string                        `json:"name"`
 	LoadBalancer       loadbalancer.LoadBalancerInfo `json:"load_balancer"`
 	HealthCheck        string                        `json:"health_check"`

--- a/pkg/lbaas/frontend/api.go
+++ b/pkg/lbaas/frontend/api.go
@@ -2,9 +2,11 @@ package frontend
 
 import (
 	"context"
-	"github.com/anexia-it/go-anxcloud/pkg/pagination"
+	"net/url"
 
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/pagination"
 )
 
 // API contains methods for load balancer frontend management.
@@ -23,4 +25,25 @@ type api struct {
 // NewAPI creates a new frontend API instance with the given client.
 func NewAPI(c client.Client) API {
 	return &api{c}
+}
+
+// EndpointURL returns the URL where to retrieve objects of type Frontend and the identifier of the given Frontend.
+// It implements the api.Object interface on *Frontend, making it usable with the generic API client.
+func (f *Frontend) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, string, error) {
+	url, err := url.ParseRequestURI("/api/LBaaS/v1/frontend.json")
+	return url, f.Identifier, err
+}
+
+// FilterAPIRequestBody generates the request body for creating a new Frontend, which differs from the Frontend object.
+func (f *Frontend) FilterAPIRequestBody(op types.Operation, options types.Options) (interface{}, error) {
+	if op == types.OperationCreate {
+		return map[string]string{
+			"name":            f.Name,
+			"load_balancer":   f.LoadBalancer.Identifier,
+			"default_backend": f.DefaultBackend.Identifier,
+			"state":           "4", // "newly created"
+		}, nil
+	}
+
+	return f, nil
 }

--- a/pkg/lbaas/loadbalancer/api.go
+++ b/pkg/lbaas/loadbalancer/api.go
@@ -2,9 +2,11 @@ package loadbalancer
 
 import (
 	"context"
-	"github.com/anexia-it/go-anxcloud/pkg/pagination"
+	"net/url"
 
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
+	"github.com/anexia-it/go-anxcloud/pkg/pagination"
 )
 
 // API contains load balancer actions.
@@ -21,4 +23,24 @@ type api struct {
 // NewAPI creates a new load balancer API instance with the given client.
 func NewAPI(c client.Client) API {
 	return &api{c}
+}
+
+// EndpointURL returns the URL where to retrieve objects of type Loadbalancer and the identifier of the given Loadbalancer.
+// It implements the api.Object interface on *Loadbalancer, making it usable with the generic API client.
+func (lb *Loadbalancer) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
+	url, err := url.ParseRequestURI("/api/LBaaS/v1/loadbalancer.json")
+	return url, err
+}
+
+// FilterAPIRequestBody generates the request body for creating a new Loadbalancer, which differs from the Loadbalancer object.
+func (lb *Loadbalancer) FilterAPIRequestBody(op types.Operation, options types.Options) (interface{}, error) {
+	if op == types.OperationCreate {
+		return map[string]string{
+			"name":       lb.Name,
+			"ip_address": lb.IpAddress,
+			"state":      "2",
+		}, nil
+	}
+
+	return lb, nil
 }

--- a/pkg/lbaas/loadbalancer/loadbalancer.go
+++ b/pkg/lbaas/loadbalancer/loadbalancer.go
@@ -16,13 +16,13 @@ const (
 
 // LoadBalancerInfo holds the identifier and the name of a load balancer
 type LoadBalancerInfo struct {
-	Identifier string `json:"identifier"`
+	Identifier string `json:"identifier" anxcloud:"identifier"`
 	Name       string `json:"name"`
 }
 
 // RuleInfo holds the name and identifier of a rule.
 type RuleInfo struct {
-	Identifier string `json:"identifier"`
+	Identifier string `json:"identifier" anxcloud:"identifier"`
 	Name       string `json:"name"`
 }
 
@@ -30,7 +30,7 @@ type RuleInfo struct {
 type Loadbalancer struct {
 	CustomerIdentifier string     `json:"customer_identifier"`
 	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier"`
+	Identifier         string     `json:"identifier" anxcloud:"identifier"`
 	Name               string     `json:"name"`
 	IpAddress          string     `json:"ip_address"`
 	AutomationRules    []RuleInfo `json:"automation_rules"`


### PR DESCRIPTION
### Description

This PR adds a new generic API client only requiring a handful lines of code on an API resource to be compatible to it. It's inspired by the kubernetes client, but not completely following it.

Many people reviewing this would be appreciated, while it seems to work with the already implemented API resources, I'm not sure if it's generic enough for all our APIs.

Feedback on the usage interface of this new client is also appreciated, I have uploaded the docs for this branch to the webserver to my [home router](https://karl.lf-net.org/go-anxcloud/pkg/github.com/anexia-it/go-anxcloud/pkg/api/) (it's a `wget -nH -m $godoc_server` and some nginx redirects).

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* adding a new generic API client, hopefully leading to way less code duplication in this package. The existing interfaces are still fully supported and not (yet, might happen in the future) deprecated.
```

### References

* https://github.com/anexia-it/go-anxcloud/pull/45#issuecomment-937768965

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
