### PR TITLE
✨💥: add BaseURL option for client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,10 +25,11 @@ const (
 	VLANEnvName = "ANEXIA_VLAN_ID"
 	// IntegrationTestEnvName is the name of the environment variable that enables integration tests if present.
 	IntegrationTestEnvName = "ANEXIA_INTEGRATION_TESTS_ON"
-	// DefaultBaseURL is the default base URL used for requests.
-	DefaultBaseURL = "https://engine.anexia-it.com"
 	// DefaultRequestTimeout is a suggested timeout for API calls.
 	DefaultRequestTimeout = 10 * time.Second
+
+	// defaultBaseURL is the default base URL used for requests.
+	defaultBaseURL = "https://engine.anexia-it.com"
 )
 
 // ErrEnvMissing indicates an environment variable is missing.
@@ -89,6 +90,7 @@ type optionSet struct {
 	token      string
 	logger     *logr.Logger
 	userAgent  string
+	baseURL    string
 }
 
 // Option is a optional parameter for the New method.
@@ -164,6 +166,13 @@ func HTTPClient(c *http.Client) Option {
 	}
 }
 
+func BaseURL(baseURL string) Option {
+	return func(o *optionSet) error {
+		o.baseURL = baseURL
+		return nil
+	}
+}
+
 // ErrConfiguration is raised when the given configuration is insufficient or erroneous.
 var ErrConfiguration = errors.New("could not configure client")
 
@@ -191,12 +200,17 @@ func New(options ...Option) (Client, error) {
 		optionSet.logger = &logger
 	}
 
+	if optionSet.baseURL == "" {
+		optionSet.baseURL = defaultBaseURL
+	}
+
 	if optionSet.token != "" {
 		return &tokenClient{
 			token:      optionSet.token,
 			httpClient: optionSet.httpClient,
 			logger:     *optionSet.logger,
 			userAgent:  optionSet.userAgent,
+			baseURL:    optionSet.baseURL,
 		}, nil
 	}
 

--- a/pkg/client/token.go
+++ b/pkg/client/token.go
@@ -12,10 +12,11 @@ type tokenClient struct {
 	httpClient *http.Client
 	logger     logr.Logger
 	userAgent  string
+	baseURL    string
 }
 
 func (t tokenClient) BaseURL() string {
-	return DefaultBaseURL
+	return t.baseURL
 }
 
 func (t tokenClient) Do(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
### Description

This also un-exports DefaultBaseURL so enforce users of this package using the BaseURL method on the client, so they are not surprised by using another URL as the client is configured to use.

I need this for my integration test refactorings and believe it's a good option to have anyway.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Unexporting `pkg/client.DefaultBaseURL` to prevent relying on that while the client is configured for another BaseURL
```

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
