### PR TITLE
👷📈: enable codecov coverage reports

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,13 @@ jobs:
         env:
           ANEXIA_TOKEN: ${{ secrets.ANEXIA_TOKEN }}
         run: make func-test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.out
+          flags: integration
+          verbose: true
 
   # Repo owner has commented /ok-to-test on a (fork-based) pull request
   integration-fork:
@@ -69,3 +76,12 @@ jobs:
             });
 
             return result;
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.out
+          flags: integration
+          verbose: true
+          override_pr: ${{ github.event.client_payload.pull_request.number }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,3 +10,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: run unit tests
         run: make test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.out
+          flags: unittests
+          verbose: true

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ benchmark:
 
 .PHONY: test
 test:
-	CGO_ENABLED=1 go test -cover -timeout 0 -race ./pkg/...
+	CGO_ENABLED=1 go test -coverpkg ./pkg/... -coverprofile coverage.out -timeout 0 -race ./pkg/...
 
 .PHONY: func-test
 func-test:
-	CGO_ENABLED=1 go test -cover -timeout 180m ./tests/...
+	CGO_ENABLED=1 go test -coverpkg ./pkg/... -coverprofile coverage.out -timeout 180m ./tests/...
 
 .PHONY: go-lint
 go-lint:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+comment:
+  # we upload two reports per commit: unittests and integration, comment only when
+  # both arrived to reduce confusion over incomplete reports.
+  after_n_builds: 2


### PR DESCRIPTION
### Description

This pull request adds coverage report comments on every pull request - hopefully starting with this one.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
