### PR TITLE
Enable unit and integration tests on main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,8 @@
 # Run secret-dependent integration tests only after /ok-to-test approval
 on:
+  push:
+    branches:
+      - main
   pull_request:
   repository_dispatch:
     types: [ok-to-test-command]
@@ -10,7 +13,9 @@ jobs:
   # Branch-based pull request
   integration-trusted:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+      || github.event_name == 'push' 
     steps:
       - name: Branch based PR checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,9 @@
 name: Unit tests
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
### Description

Unit- and integration tests are only run for pull requests, this PR changes that to also run them for pushes to main branch (i.e. after a PR is merged). This creates code coverage reports for the main branch, usable as a base for PRs.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References

This was missed in #60 because I just don't know a lot about github actions, yet..

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
