### PR TITLE
SYSENG-526 ✨: add interface to get client metrics

### DIFF
--- a/pkg/client/metrics.go
+++ b/pkg/client/metrics.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Metric is a named ... metric. We have them named in prometheus format, but using this type and the given
+// constants, non-prometheus users don't have to care about the actual name.
+type Metric string
+
+const (
+	// MetricRequestDuration is the time in seconds it took to send the request until a response was received.
+	MetricRequestDuration Metric = "http_request_duration_seconds"
+
+	// MetricRequestCount is the number of requests sent for the given labels. It is a counter, delivered
+	// as 1 for increment and -1 for decrement.
+	MetricRequestCount Metric = "http_request_total"
+
+	// MetricRequestInflight is the number of requests currently waiting for a response. It is a counter,
+	// delivered as 1 for increment and -1 for decrement.
+	MetricRequestInflight Metric = "http_requests_in_flight"
+)
+
+// MetricLabel is the key for the labels-map we give when passing metrics to the receiver. It again is just a
+// prometheus-like label name but non-prometheus users don't have to care about the actual name this way.
+type MetricLabel string
+
+const (
+	// MetricLabelResource contains the name of the resource the given metric is about - this might be a
+	// request URI, the name of a type or something similar. It will be the same for all requests for
+	// the same resource-kind.
+	MetricLabelResource MetricLabel = "resource"
+
+	// MetricTagMethod contains the HTTP verb used in the request.
+	MetricLabelMethod MetricLabel = "method"
+
+	// MetricTagStatus contains the status code we received for the request.
+	MetricLabelStatus MetricLabel = "status"
+)
+
+// MetricReceiver receives a bunch of metrics with the same labels. Counter metrics will be delivered
+// as 1 for increment and -1 for decrement.
+type MetricReceiver func(metrics map[Metric]float64, labels map[MetricLabel]string)
+
+type metricsTransport struct {
+	baseTransport http.RoundTripper
+	receiver      MetricReceiver
+}
+
+func (m metricsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	labels := make(map[MetricLabel]string, 3)
+
+	labels[MetricLabelResource] = req.URL.Path
+	labels[MetricLabelMethod] = req.Method
+
+	start := time.Now()
+	m.receiver(
+		map[Metric]float64{
+			MetricRequestInflight: 1,
+		},
+		labels,
+	)
+
+	response, err := m.baseTransport.RoundTrip(req)
+
+	if response != nil {
+		labels[MetricLabelStatus] = strconv.Itoa(response.StatusCode)
+	} else {
+		labels[MetricLabelStatus] = "-1"
+	}
+
+	m.receiver(
+		map[Metric]float64{
+			MetricRequestDuration: time.Since(start).Seconds(),
+			MetricRequestInflight: -1,
+			MetricRequestCount:    1,
+		},
+		labels,
+	)
+
+	return response, err
+}
+
+func wrapClientForMetrics(c *http.Client, r MetricReceiver) *http.Client {
+	transport := http.DefaultTransport
+
+	if c.Transport != nil {
+		transport = c.Transport
+	}
+
+	return &http.Client{
+		Transport: metricsTransport{
+			baseTransport: transport,
+			receiver:      r,
+		},
+		CheckRedirect: c.CheckRedirect,
+		Jar:           c.Jar,
+		Timeout:       c.Timeout,
+	}
+}

--- a/pkg/client/metrics_test.go
+++ b/pkg/client/metrics_test.go
@@ -1,0 +1,221 @@
+package client
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+type metricTestTransport struct {
+	numRequests int
+}
+
+func (m *metricTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.numRequests++
+
+	if m.numRequests > 1 {
+		return nil, errors.New("test error")
+	}
+
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+var _ = Describe("client metrics", func() {
+	type metricReceiverCall struct {
+		metrics map[Metric]float64
+		labels  map[MetricLabel]string
+	}
+
+	var server *ghttp.Server
+	var client Client
+	var hc *http.Client
+
+	var receivedMetrics []metricReceiverCall
+	var countRequests int
+	var countInflight int
+	var requestDurationTotal float64
+
+	BeforeEach(func() {
+		hc = http.DefaultClient
+	})
+
+	JustBeforeEach(func() {
+		countRequests = 0
+		countInflight = 0
+		requestDurationTotal = 0
+
+		receivedMetrics = make([]metricReceiverCall, 0, 2)
+
+		server = ghttp.NewServer()
+
+		client, _ = New(
+			WithClient(hc),
+			ParseEngineErrors(false),
+			IgnoreMissingToken(),
+			BaseURL(server.URL()),
+			WithMetricReceiver(func(m map[Metric]float64, l map[MetricLabel]string) {
+				if v, o := m[MetricRequestCount]; o {
+					countRequests += int(v)
+				}
+
+				if v, o := m[MetricRequestInflight]; o {
+					countInflight += int(v)
+				}
+
+				if v, o := m[MetricRequestDuration]; o {
+					requestDurationTotal += v
+				}
+
+				mrc := metricReceiverCall{
+					metrics: make(map[Metric]float64, len(m)),
+					labels:  make(map[MetricLabel]string, len(l)),
+				}
+
+				for key, val := range m {
+					mrc.metrics[key] = val
+				}
+
+				for key, val := range l {
+					mrc.labels[key] = val
+				}
+
+				receivedMetrics = append(receivedMetrics, mrc)
+			}),
+		)
+	})
+
+	It("delivers counter metrics as expected", func() {
+		type testRequest struct {
+			method string
+			status int
+		}
+
+		testRequests := []testRequest{
+			{"GET", 200},
+			{"GET", 404},
+			{"POST", 200},
+			{"DELETE", 200},
+			{"GET", 500},
+		}
+
+		for i, tr := range testRequests {
+			r, err := http.NewRequest(tr.method, client.BaseURL()+"/", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			server.AppendHandlers(ghttp.RespondWith(tr.status, nil))
+			_, err = client.Do(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			firstMetric := receivedMetrics[i*2]
+			secondMetric := receivedMetrics[i*2+1]
+
+			Expect(firstMetric).To(BeEquivalentTo(
+				metricReceiverCall{
+					metrics: map[Metric]float64{
+						MetricRequestInflight: 1,
+					},
+					labels: map[MetricLabel]string{
+						MetricLabelResource: "/",
+						MetricLabelMethod:   tr.method,
+					},
+				},
+			))
+
+			Expect(secondMetric.labels).To(BeEquivalentTo(
+				map[MetricLabel]string{
+					MetricLabelResource: "/",
+					MetricLabelMethod:   tr.method,
+					MetricLabelStatus:   strconv.Itoa(tr.status),
+				},
+			))
+		}
+
+		Expect(countRequests).To(Equal(len(testRequests)))
+		Expect(countInflight).To(Equal(0))
+	})
+
+	It("delivers request duration metric as expected", func() {
+		server.AppendHandlers(ghttp.CombineHandlers(
+			func(res http.ResponseWriter, req *http.Request) {
+				time.Sleep(500 * time.Millisecond)
+			},
+			ghttp.RespondWith(200, nil),
+		))
+
+		r, err := http.NewRequest("GET", client.BaseURL()+"/", nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = client.Do(r)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(countRequests).To(Equal(1))
+		Expect(countInflight).To(Equal(0))
+		Expect(requestDurationTotal).To(BeNumerically("~", 0.5, 0.1))
+	})
+
+	Context("when configured with a custom http.Client", func() {
+		var transport metricTestTransport
+		BeforeEach(func() {
+			transport = metricTestTransport{}
+
+			hc = &http.Client{
+				Transport: &transport,
+			}
+		})
+
+		It("uses the transport of the custom http.Client", func() {
+			server.AppendHandlers(ghttp.RespondWith(200, nil))
+
+			r, err := http.NewRequest("GET", client.BaseURL()+"/", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Do(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(countRequests).To(Equal(1))
+			Expect(countInflight).To(Equal(0))
+			Expect(requestDurationTotal).To(BeNumerically("~", 0, 0.1))
+
+			Expect(transport.numRequests).To(Equal(1))
+		})
+
+		It("uses status code -1 for transport returning an error", func() {
+			server.AppendHandlers(
+				ghttp.RespondWith(200, nil),
+				// only first request comes through to the server, second is catched in metricTestTransport.RoundTrip
+			)
+
+			r, err := http.NewRequest("GET", client.BaseURL()+"/", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Do(r)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(countRequests).To(Equal(1))
+			Expect(countInflight).To(Equal(0))
+			Expect(requestDurationTotal).To(BeNumerically("~", 0, 0.1))
+
+			Expect(transport.numRequests).To(Equal(1))
+
+			r, err = http.NewRequest("GET", client.BaseURL()+"/", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Do(r)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("test error"))
+
+			Expect(countRequests).To(Equal(2))
+			Expect(countInflight).To(Equal(0))
+			Expect(requestDurationTotal).To(BeNumerically("~", 0, 0.1))
+			Expect(transport.numRequests).To(Equal(2))
+
+			Expect(receivedMetrics[1].labels[MetricLabelStatus]).To(Equal("200"))
+			Expect(receivedMetrics[3].labels[MetricLabelStatus]).To(Equal("-1"))
+		})
+	})
+})


### PR DESCRIPTION
### Description

Add interface to retrieve metrics from client, specifically request (inflight) counters and duration. Can be used for prometheus metrics in CCM or timing info in terraform provider for example.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* add new feature to retrieve metrics from client
```

### References

SYSENG-526

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
