### PR TITLE
Add generic client interfaces to core/resource API

### DIFF
--- a/pkg/core/resource/api.go
+++ b/pkg/core/resource/api.go
@@ -25,18 +25,20 @@ type api struct {
 func (i Info) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
 	u, err := url.ParseRequestURI(pathPrefix)
 
+	switch op {
 	// OperationCreate is not supported because the API does not exist in the engine.
 	// OperationDestroy and OperationUpdate is not yet implemented
-	switch op {
 	case types.OperationCreate, types.OperationDestroy, types.OperationUpdate:
 		return nil, genericAPI.ErrOperationNotSupported
 	}
 
 	if op == types.OperationList {
 		query := u.Query()
+
 		if len(i.Tags) > 1 {
 			logr.FromContextOrDiscard(ctx).Info("Listing with multiple tags isn't supported. Only first one used")
 		}
+
 		if len(i.Tags) > 0 {
 			query.Add("tag_name", i.Tags[0])
 		}

--- a/pkg/core/resource/api.go
+++ b/pkg/core/resource/api.go
@@ -25,6 +25,8 @@ type api struct {
 func (i Info) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
 	u, err := url.ParseRequestURI(pathPrefix)
 
+	// OperationCreate is not supported because the API does not exist in the engine.
+	// OperationDestroy and OperationUpdate is not yet implemented
 	switch op {
 	case types.OperationCreate, types.OperationDestroy, types.OperationUpdate:
 		return nil, genericAPI.ErrOperationNotSupported

--- a/pkg/core/resource/api.go
+++ b/pkg/core/resource/api.go
@@ -22,9 +22,16 @@ type api struct {
 	client client.Client
 }
 
-func (i Info) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
+func (i Info) EndpointURL(ctx context.Context) (*url.URL, error) {
 	u, err := url.ParseRequestURI(pathPrefix)
+	if err != nil {
+		return nil, err
+	}
 
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	switch op {
 	// OperationCreate is not supported because the API does not exist in the engine.
 	// OperationDestroy and OperationUpdate is not yet implemented

--- a/pkg/core/resource/api.go
+++ b/pkg/core/resource/api.go
@@ -2,6 +2,10 @@ package resource
 
 import (
 	"context"
+	genericAPI "github.com/anexia-it/go-anxcloud/pkg/api"
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+	"github.com/go-logr/logr"
+	"net/url"
 
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 )
@@ -16,6 +20,27 @@ type API interface {
 
 type api struct {
 	client client.Client
+}
+
+func (i Info) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, error) {
+	u, err := url.ParseRequestURI(pathPrefix)
+
+	switch op {
+	case types.OperationCreate, types.OperationDestroy, types.OperationUpdate:
+		return nil, genericAPI.ErrOperationNotSupported
+	}
+
+	if op == types.OperationList {
+		query := u.Query()
+		if len(i.Tags) > 1 {
+			logr.FromContextOrDiscard(ctx).Info("Listing with multiple tags isn't supported. Only first one used")
+		}
+		if len(i.Tags) > 0 {
+			query.Add("tag_name", i.Tags[0])
+		}
+		u.RawQuery = query.Encode()
+	}
+	return u, err
 }
 
 // NewAPI creates a new tags API instance with the given client.

--- a/pkg/core/resource/resource.go
+++ b/pkg/core/resource/resource.go
@@ -25,7 +25,7 @@ type Type struct {
 
 // Info contains all information about a resource.
 type Info struct {
-	Identifier string   `json:"identifier"`
+	Identifier string   `json:"identifier" anxcloud:"identifier"`
 	Name       string   `json:"name"`
 	Type       Type     `json:"resource_type"`
 	Tags       []string `json:"tags"`

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -10,11 +10,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Client tests", func() {
+var _ = Describe("client tests", func() {
 
-	Context("Echo endpoint", func() {
+	Context("echo endpoint", func() {
 
-		It("Should be able to communicate with Anexia echo endpoint", func() {
+		It("should be able to communicate with Anexia echo endpoint", func() {
 			c, err := client.New(client.TokenFromEnv(false))
 			Expect(err).NotTo(HaveOccurred())
 

--- a/tests/core_test.go
+++ b/tests/core_test.go
@@ -86,7 +86,8 @@ var _ = Describe("Core API endpoint tests", func() {
 			genericAPI, err := api.NewAPI(api.WithClientOptions(client.AuthFromEnv(false)))
 			Expect(err).ToNot(HaveOccurred())
 			var pageIter types.PageInfo
-			genericAPI.List(ctx, &resource.Info{}, api.Paged(1, 100, &pageIter))
+			err = genericAPI.List(ctx, &resource.Info{}, api.Paged(1, 100, &pageIter))
+			Expect(err).ToNot(HaveOccurred())
 			var resInfo []resource.Info
 			Expect(pageIter.Next(&resInfo)).To(BeTrue())
 			Expect(resInfo).ToNot(BeEmpty())

--- a/tests/core_test.go
+++ b/tests/core_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Core API endpoint tests", func() {
 			Expect(resInfo[0].Identifier).ToNot(BeEmpty())
 		})
 
-		FIt("It should throw an error for unsupported operations for the genric API client", func() {
+		It("It should throw an error for unsupported operations for the genric API client", func() {
 			// make sure at least one resource exists
 			ctx := context.Background()
 			createBackend(ctx, cli, nil)

--- a/tests/core_test.go
+++ b/tests/core_test.go
@@ -17,7 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Core API endpoint tests", func() {
+var _ = Describe("core API endpoint tests", func() {
 
 	var cli client.Client
 
@@ -38,16 +38,16 @@ var _ = Describe("Core API endpoint tests", func() {
 		cleanupHandlers = []CleanUpHandler{}
 	})
 
-	Context("Location endpoint", func() {
+	Context("location endpoint", func() {
 
-		It("Should list all available locations, and get the first entry by ID and code", func() {
+		It("should list all available locations, and get the first entry by ID and code", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			_, err := location.NewAPI(cli).List(ctx, 1, 1000, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Should get the first location entry by ID", func() {
+		It("should get the first location entry by ID", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			list, err := location.NewAPI(cli).List(ctx, 1, 1000, "")
@@ -57,7 +57,7 @@ var _ = Describe("Core API endpoint tests", func() {
 			Expect(l).To(Equal(list[0]))
 		})
 
-		It("Should get the first location entry by code", func() {
+		It("should get the first location entry by code", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			list, err := location.NewAPI(cli).List(ctx, 1, 1000, "")
@@ -69,16 +69,16 @@ var _ = Describe("Core API endpoint tests", func() {
 		})
 	})
 
-	Context("Resource endpoint", func() {
+	Context("resource endpoint", func() {
 
-		It("Should list all created resources", func() {
+		It("should list all created resources", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			_, err := resource.NewAPI(cli).List(ctx, 1, 1000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("It should list resource using generic API client", func() {
+		It("it should list resource using generic API client", func() {
 			// make sure at least one resource exists
 			ctx := context.Background()
 			createBackend(ctx, cli, nil)
@@ -94,7 +94,7 @@ var _ = Describe("Core API endpoint tests", func() {
 			Expect(resInfo[0].Identifier).ToNot(BeEmpty())
 		})
 
-		It("It should throw an error for unsupported operations for the genric API client", func() {
+		It("it should throw an error for unsupported operations for the genric API client", func() {
 			// make sure at least one resource exists
 			ctx := context.Background()
 			createBackend(ctx, cli, nil)
@@ -106,8 +106,8 @@ var _ = Describe("Core API endpoint tests", func() {
 		})
 	})
 
-	Context("Service endpoint", func() {
-		It("Should list all created services", func() {
+	Context("service endpoint", func() {
+		It("should list all created services", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			_, err := service.NewAPI(cli).List(ctx, 1, 1000)
@@ -115,8 +115,8 @@ var _ = Describe("Core API endpoint tests", func() {
 		})
 	})
 
-	Context("Tags endpoint", func() {
-		It("Should list all created tags", func() {
+	Context("tags endpoint", func() {
+		It("should list all created tags", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			_, err := tags.NewAPI(cli).List(ctx, 1, 1000, "", "", "", "", true)

--- a/tests/core_test.go
+++ b/tests/core_test.go
@@ -38,7 +38,7 @@ var _ = Describe("core API endpoint tests", func() {
 		cleanupHandlers = []CleanUpHandler{}
 	})
 
-	Context("location endpoint", func() {
+	Describe("location endpoint", func() {
 
 		It("should list all available locations, and get the first entry by ID and code", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
@@ -69,7 +69,7 @@ var _ = Describe("core API endpoint tests", func() {
 		})
 	})
 
-	Context("resource endpoint", func() {
+	Describe("resource endpoint", func() {
 		It("should list all created resources", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
@@ -108,7 +108,7 @@ var _ = Describe("core API endpoint tests", func() {
 		})
 	})
 
-	Context("service endpoint", func() {
+	Describe("service endpoint", func() {
 		It("should list all created services", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
@@ -117,7 +117,7 @@ var _ = Describe("core API endpoint tests", func() {
 		})
 	})
 
-	Context("tags endpoint", func() {
+	Describe("tags endpoint", func() {
 		It("should list all created tags", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()

--- a/tests/ipam_test.go
+++ b/tests/ipam_test.go
@@ -22,9 +22,9 @@ var _ = Describe("IPAM API endpoint tests", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Context("Address endpoint", func() {
+	Context("address endpoint", func() {
 
-		It("Should list all available addresses", func() {
+		It("should list all available addresses", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			_, err := address.NewAPI(cli).List(ctx, 1, 1000, "")
@@ -33,16 +33,16 @@ var _ = Describe("IPAM API endpoint tests", func() {
 
 	})
 
-	Context("Prefix endpoint", func() {
+	Context("prefix endpoint", func() {
 
-		It("Should list all prefixes", func() {
+		It("should list all prefixes", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			_, err := prefix.NewAPI(cli).List(ctx, 1, 1000)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Should create a new prefix and delete it later", func() {
+		It("should create a new prefix and delete it later", func() {
 			p := prefix.NewAPI(cli)
 			a := address.NewAPI(cli)
 			ipV4 := 4
@@ -50,12 +50,12 @@ var _ = Describe("IPAM API endpoint tests", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 			defer cancel()
 
-			By("Creating a new prefix")
+			By("creating a new prefix")
 			summary, err := p.Create(ctx, prefix.NewCreate(locationID, vlanID, ipV4, prefix.TypePrivate, networkMask))
 			Expect(err).NotTo(HaveOccurred())
 
 			var info prefix.Info
-			By("Waiting for prefix to be 'Active'")
+			By("waiting for prefix to be 'Active'")
 			Eventually(func() string {
 				info, err = p.Get(ctx, summary.ID)
 				Expect(err).NotTo(HaveOccurred())
@@ -71,16 +71,16 @@ var _ = Describe("IPAM API endpoint tests", func() {
 			Expect(filtered).To(HaveLen(8)) // we expect all IPs to be already created
 			Expect(filtered).ToNot(BeEmpty())
 
-			By("Updating the prefix")
+			By("updating the prefix")
 			_, err = p.Update(ctx, summary.ID, prefix.Update{CustomerDescription: "something else"})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Deleting the prefix")
+			By("deleting the prefix")
 			err = p.Delete(ctx, summary.ID)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Should create a new empty prefix and delete it later", func() {
+		It("should create a new empty prefix and delete it later", func() {
 			p := prefix.NewAPI(cli)
 			a := address.NewAPI(cli)
 			ipV4 := 4
@@ -88,14 +88,14 @@ var _ = Describe("IPAM API endpoint tests", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 			defer cancel()
 
-			By("Creating a new prefix")
+			By("creating a new prefix")
 			create := prefix.NewCreate(locationID, vlanID, ipV4, prefix.TypePrivate, networkMask)
 			create.CreateEmpty = true
 			summary, err := p.Create(ctx, create)
 			Expect(err).NotTo(HaveOccurred())
 
 			var info prefix.Info
-			By("Waiting for prefix to be 'Active'")
+			By("waiting for prefix to be 'Active'")
 			Eventually(func() string {
 				info, err = p.Get(ctx, summary.ID)
 				Expect(err).NotTo(HaveOccurred())
@@ -111,11 +111,11 @@ var _ = Describe("IPAM API endpoint tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(filtered).To(HaveLen(3))
 
-			By("Updating the prefix")
+			By("updating the prefix")
 			_, err = p.Update(ctx, summary.ID, prefix.Update{CustomerDescription: "something else"})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Deleting the prefix")
+			By("deleting the prefix")
 			err = p.Delete(ctx, summary.ID)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/tests/lbaas_test.go
+++ b/tests/lbaas_test.go
@@ -42,7 +42,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 	})
 
 	Context("LBaaS - Loadbalancers", func() {
-		It("Get load balancers", func() {
+		It("get load balancers", func() {
 			ctx := context.Background()
 
 			loadBalancers, err := lbaas.NewAPI(cli).LoadBalancer().Get(ctx, 1, 50)
@@ -52,7 +52,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(len(loadBalancers)).Should(BeNumerically(">=", 2))
 		})
 
-		It("Get a specific load balancer", func() {
+		It("get a specific load balancer", func() {
 			ctx := context.Background()
 			api := lbaas.NewAPI(cli).LoadBalancer()
 
@@ -71,7 +71,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 	})
 
 	Context("LBaaS - Backend", func() {
-		It("Create a Backend", func() {
+		It("create a Backend", func() {
 			ctx := context.Background()
 			definition := &backend.Definition{
 				Name:         randomName(),
@@ -88,7 +88,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(backend.Identifier).ToNot(BeEmpty())
 		})
 
-		It("Get Backends", func() {
+		It("get Backends", func() {
 			ctx := context.Background()
 			createBackend(ctx, cli, nil)
 
@@ -98,7 +98,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(backends).ToNot(BeEmpty())
 		})
 
-		It("Get a specific backend", func() {
+		It("get a specific backend", func() {
 			ctx := context.Background()
 			testBackend := createBackend(ctx, cli, nil)
 
@@ -108,7 +108,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(fetchedBackend).To(BeEquivalentTo(testBackend))
 		})
 
-		It("Update a specific backend", func() {
+		It("update a specific backend", func() {
 			ctx := context.Background()
 			testBackend := createBackend(ctx, cli, nil)
 
@@ -127,7 +127,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 	})
 
 	Context("LBaaS - Servers", func() {
-		It("Create server", func() {
+		It("create server", func() {
 			ctx := context.Background()
 
 			definition := &server.Definition{
@@ -146,7 +146,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(createdServer.Backend.Identifier).To(BeEquivalentTo(definition.Backend))
 		})
 
-		It("Get servers", func() {
+		It("get servers", func() {
 			ctx := context.Background()
 			createServer(ctx, cli, nil)
 
@@ -155,7 +155,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(servers).ToNot(BeEmpty())
 		})
 
-		It("Get a specific server", func() {
+		It("get a specific server", func() {
 			ctx := context.Background()
 			createdServer := createServer(ctx, cli, nil)
 
@@ -164,7 +164,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(fetchedServer).To(BeEquivalentTo(createdServer))
 		})
 
-		It("Update a specific server", func() {
+		It("update a specific server", func() {
 			ctx := context.Background()
 			createdServer := createServer(ctx, cli, nil)
 
@@ -184,7 +184,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 	})
 
 	Context("LBaaS - Binds", func() {
-		It("Create Bind", func() {
+		It("create Bind", func() {
 			ctx := context.Background()
 			definition := &bind.Definition{
 				Name:     randomName(),
@@ -196,7 +196,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(createdBind.Frontend.Identifier).To(BeEquivalentTo(definition.Frontend))
 		})
 
-		It("Get Binds", func() {
+		It("get Binds", func() {
 			ctx := context.Background()
 			createBind(ctx, cli, nil)
 
@@ -205,7 +205,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(binds).ToNot(HaveLen(0))
 		})
 
-		It("Get a specific Bind", func() {
+		It("get a specific Bind", func() {
 			ctx := context.Background()
 			createdBind := createBind(ctx, cli, nil)
 
@@ -214,7 +214,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(fetchedBind).To(BeEquivalentTo(createdBind))
 		})
 
-		It("Update a specific Bind", func() {
+		It("update a specific Bind", func() {
 			ctx := context.Background()
 			createdBind := createBind(ctx, cli, nil)
 
@@ -232,7 +232,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 	})
 
 	Context("LBaaS - Frontends", func() {
-		It("Create frontend", func() {
+		It("create frontend", func() {
 			ctx := context.Background()
 			backend := createBackend(ctx, cli, nil)
 			definition := frontend.Definition{
@@ -250,7 +250,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(frontend.LoadBalancer.Identifier).To(BeEquivalentTo(definition.LoadBalancer))
 		})
 
-		It("Get load balancer frontends", func() {
+		It("get load balancer frontends", func() {
 			ctx := context.Background()
 			createFrontend(ctx, cli, nil)
 
@@ -260,7 +260,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(frontends).ToNot(BeEmpty())
 		})
 
-		It("Get a specific frontend", func() {
+		It("get a specific frontend", func() {
 			ctx := context.Background()
 			api := lbaas.NewAPI(cli).Frontend()
 			createdFrontend := createFrontend(ctx, cli, nil)
@@ -271,7 +271,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(fetchedFrontend).To(BeEquivalentTo(createdFrontend))
 		})
 
-		It("Update a specific frontend", func() {
+		It("update a specific frontend", func() {
 			ctx := context.Background()
 			api := lbaas.NewAPI(cli).Frontend()
 			createdFrontend := createFrontend(ctx, cli, nil)
@@ -293,7 +293,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 	})
 
 	Context("LBaaS - ACLs", func() {
-		It("Create ACL", func() {
+		It("create ACL", func() {
 			ctx := context.Background()
 			backend := createBackend(ctx, cli, nil)
 			definition := &acl.Definition{
@@ -316,7 +316,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(createdACL.Criterion).To(BeEquivalentTo(definition.Criterion))
 		})
 
-		It("Get ACLs", func() {
+		It("get ACLs", func() {
 			ctx := context.Background()
 			createACL(ctx, cli, nil)
 			api := acl.NewAPI(cli)
@@ -326,7 +326,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(acls).NotTo(BeEmpty())
 		})
 
-		It("Get specific ACL", func() {
+		It("get specific ACL", func() {
 			ctx := context.Background()
 			createdACL := createACL(ctx, cli, nil)
 			api := acl.NewAPI(cli)
@@ -336,7 +336,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(fetchedACL).To(BeEquivalentTo(createdACL))
 		})
 
-		It("Update a specific ACL", func() {
+		It("update a specific ACL", func() {
 			ctx := context.Background()
 			createdACL := createACL(ctx, cli, nil)
 			api := acl.NewAPI(cli)

--- a/tests/nic_type_test.go
+++ b/tests/nic_type_test.go
@@ -23,7 +23,7 @@ var _ = Describe("NIC type API endpoint tests", func() {
 
 	Context("NIC type endpoint", func() {
 
-		It("Should list all available NIC types", func() {
+		It("should list all available NIC types", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			nicTypes, err := nictype.NewAPI(cli).List(ctx)

--- a/tests/pagination_test.go
+++ b/tests/pagination_test.go
@@ -34,9 +34,9 @@ var _ = Describe("LBaaS Service Tests", func() {
 		cleanupHandlers = []CleanUpHandler{}
 	})
 
-	Context("Pagination Core Functionality", func() {
+	Context("pagination Core Functionality", func() {
 		const numberOfTests = 5
-		It("Testing pagination for frontend", func() {
+		It("testing pagination for frontend", func() {
 			ctx := context.Background()
 
 			for i := 0; i < numberOfTests; i++ {
@@ -57,7 +57,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			}
 		})
 
-		It("Testing pagination for backends", func() {
+		It("testing pagination for backends", func() {
 			ctx := context.Background()
 
 			for i := 0; i < numberOfTests; i++ {
@@ -78,7 +78,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			}
 		})
 
-		It("Testing pagination for server", func() {
+		It("testing pagination for server", func() {
 			ctx := context.Background()
 
 			for i := 0; i < numberOfTests; i++ {
@@ -99,7 +99,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			}
 		})
 
-		It("Testing pagination for binds", func() {
+		It("testing pagination for binds", func() {
 			ctx := context.Background()
 
 			for i := 0; i < numberOfTests; i++ {
@@ -121,8 +121,8 @@ var _ = Describe("LBaaS Service Tests", func() {
 		})
 	})
 
-	Context("Pagination Utility Function", func() {
-		It("Pagination As Go Channels", func() {
+	Context("pagination Utility Function", func() {
+		It("pagination As Go Channels", func() {
 			ctx := context.Background()
 
 			const numberOfBackends = 5
@@ -141,7 +141,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(counter).To(BeNumerically(">=", numberOfBackends))
 		})
 
-		It("Pagination Loop until (all)", func() {
+		It("pagination Loop until (all)", func() {
 			ctx := context.Background()
 			const numberOfTests = 5
 			for i := 0; i < numberOfTests; i++ {
@@ -159,7 +159,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(err).To(BeEquivalentTo(pagination.ErrConditionNeverMet))
 		})
 
-		It("Pagination Loop until (subset)", func() {
+		It("pagination Loop until (subset)", func() {
 			ctx := context.Background()
 			const numberOfTests = 5
 			for i := 0; i < numberOfTests; i++ {
@@ -180,7 +180,7 @@ var _ = Describe("LBaaS Service Tests", func() {
 			Expect(counter).To(BeNumerically(">=", numberOfTests-1))
 		})
 
-		It("Pagination Loop until (subset)", func() {
+		It("pagination Loop until (subset)", func() {
 			ctx := context.Background()
 			const numberOfTests = 5
 			for i := 0; i < numberOfTests; i++ {

--- a/tests/param_test.go
+++ b/tests/param_test.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 )
 
-var _ = Describe("Parameter Builder Tests", func() {
-	It("Should Create Parameter", func() {
+var _ = Describe("parameter Builder Tests", func() {
+	It("should Create Parameter", func() {
 		const testKey = "testKey"
 		const testValue = "testValue"
 		builder := param.ParameterBuilder(testKey)

--- a/tests/vlan_test.go
+++ b/tests/vlan_test.go
@@ -23,21 +23,21 @@ var _ = Describe("VLAN API endpoint tests", func() {
 
 	Context("VLAN endpoint", func() {
 
-		It("Should list all available VLANs", func() {
+		It("should list all available VLANs", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 			defer cancel()
 			_, err := vlan.NewAPI(cli).List(ctx, 1, 1000, "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("Should create a VLAN, update it and delete it later", func() {
+		It("should create a VLAN, update it and delete it later", func() {
 			v := vlan.NewAPI(cli)
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 			defer cancel()
 			summary, err := v.Create(ctx, vlan.CreateDefinition{Location: locationID, VMProvisioning: false, CustomerDescription: "go SDK integration test"})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for vlan to be 'Active'")
+			By("waiting for vlan to be 'Active'")
 			Eventually(func() string {
 				info, err := v.Get(ctx, summary.Identifier)
 				Expect(err).NotTo(HaveOccurred())
@@ -45,19 +45,19 @@ var _ = Describe("VLAN API endpoint tests", func() {
 			}, 15*time.Minute, 5*time.Second).Should(Equal("Active"))
 
 			defer func() {
-				By("Deleting the vlan")
+				By("deleting the vlan")
 				err = v.Delete(ctx, summary.Identifier)
 				Expect(err).NotTo(HaveOccurred())
 			}()
 
-			By("Update the vlan")
+			By("update the vlan")
 			err = v.Update(ctx, summary.Identifier, vlan.UpdateDefinition{
 				CustomerDescription: "go SDK integration test updated",
 				VMProvisioning:      true,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Fetching the vlan again")
+			By("fetching the vlan again")
 			Eventually(func() bool {
 				vlanInfo, err := v.Get(ctx, summary.Identifier)
 				Expect(err).NotTo(HaveOccurred())

--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -73,7 +73,7 @@ func vsphereTestInit() {
 	templateID = selected[0].ID
 }
 
-var _ = PDescribe("Vsphere API endpoint tests", func() {
+var _ = PDescribe("vsphere API endpoint tests", func() {
 
 	var cli client.Client
 
@@ -96,15 +96,15 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 		})
 	})
 
-	Context("Provisioning endpoint", func() {
+	Context("provisioning endpoint", func() {
 
 		Context("VM endpoint", func() {
 
-			It("Should create a VM and delete it later", func() {
+			It("should create a VM and delete it later", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 				defer cancel()
 
-				By("Reserving a new IP address")
+				By("reserving a new IP address")
 				res, err := address.NewAPI(cli).ReserveRandom(ctx, address.ReserveRandom{
 					LocationID: locationID,
 					VlanID:     vlanID,
@@ -118,29 +118,29 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 				definition.Sockets = sockets
 				definition.SSH = randomPublicSSHKey()
 
-				By("Creating a new VM")
+				By("creating a new VM")
 				base64Encoding := true
 				provisionResponse, err := vm.NewAPI(cli).Provision(ctx, definition, base64Encoding)
 				Expect(err).NotTo(HaveOccurred())
 
-				By("Waiting for the VM to be ready")
+				By("waiting for the VM to be ready")
 				vmID, err := progress.NewAPI(cli).AwaitCompletion(ctx, provisionResponse.Identifier)
 				Expect(err).NotTo(HaveOccurred())
 
-				By("Updating the VM")
+				By("updating the VM")
 				change := vm.NewChange()
 				change.MemoryMBs = changedMemory
 				updateResponse, err := vm.NewAPI(cli).Update(ctx, vmID, change)
 				Expect(err).NotTo(HaveOccurred())
 
-				By("Waiting for VM to be ready after an update")
+				By("waiting for VM to be ready after an update")
 				newVMid, err := progress.NewAPI(cli).AwaitCompletion(ctx, updateResponse.Identifier)
 				Expect(err).NotTo(HaveOccurred())
 				if newVMid != vmID {
 					log.Fatalf("VM change resulted in a new ID: %v -> %v", vmID, newVMid)
 				}
 
-				By("Deleting the VM")
+				By("deleting the VM")
 				response, err := vm.NewAPI(cli).Deprovision(ctx, vmID, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(response.Identifier).ToNot(BeEmpty())
@@ -150,9 +150,9 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 			})
 		})
 
-		Context("Templates endpoint", func() {
+		Context("templates endpoint", func() {
 
-			It("Should list all available templates", func() {
+			It("should list all available templates", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 				defer cancel()
 
@@ -164,7 +164,7 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 
 		Context("IPs endpoint", func() {
 
-			It("Should get a free IP address", func() {
+			It("should get a free IP address", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 				defer cancel()
 
@@ -174,9 +174,9 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 
 		})
 
-		Context("Disk type endpoint", func() {
+		Context("disk type endpoint", func() {
 
-			It("Should list all available disk types", func() {
+			It("should list all available disk types", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 				defer cancel()
 
@@ -188,7 +188,7 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 
 		Context("CPU Performance Type endpoint", func() {
 
-			It("Should list all cpu performance types", func() {
+			It("should list all cpu performance types", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 				defer cancel()
 				_, err := cpuperformancetype.NewAPI(cli).List(ctx)
@@ -199,7 +199,7 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 
 		Context("VSphere Location endpoint", func() {
 
-			It("Should list all VSPhere locations", func() {
+			It("should list all VSPhere locations", func() {
 				ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 				defer cancel()
 				locations, err := location.NewAPI(cli).List(ctx, 1, 50, "", "")
@@ -211,12 +211,12 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 
 	})
 
-	Context("Info endpoint", func() {
-		It("Should create and retrieve a VM", func() {
+	Context("info endpoint", func() {
+		It("should create and retrieve a VM", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 			defer cancel()
 
-			By("Reserving a new IP address")
+			By("reserving a new IP address")
 			res, err := address.NewAPI(cli).ReserveRandom(ctx, address.ReserveRandom{
 				LocationID: locationID,
 				VlanID:     vlanID,
@@ -229,16 +229,16 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 			definition := vm.NewAPI(cli).NewDefinition(locationID, templateType, templateID, randomHostname(), cpus, memory, disk, networkInterfaces)
 			definition.SSH = randomPublicSSHKey()
 
-			By("Creating a new VM")
+			By("creating a new VM")
 			base64Encoding := true
 			provisionResponse, err := vm.NewAPI(cli).Provision(ctx, definition, base64Encoding)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Waiting for the VM to be ready")
+			By("waiting for the VM to be ready")
 			vmID, err := progress.NewAPI(cli).AwaitCompletion(ctx, provisionResponse.Identifier)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Retrieving the VM")
+			By("retrieving the VM")
 			vmInfo, err := info.NewAPI(cli).Get(ctx, vmID)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(vmInfo).NotTo(BeNil())
@@ -249,8 +249,8 @@ var _ = PDescribe("Vsphere API endpoint tests", func() {
 		})
 	})
 
-	Context("Progress Endpoint", func() {
-		It("Should handle 404 correctly", func() {
+	Context("progress Endpoint", func() {
+		It("should handle 404 correctly", func() {
 			By("using an identifiert which does not exist")
 			ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancelFunc()


### PR DESCRIPTION
### Description

Make resource compliant with generic API interfaces{}

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* core/resources - make resource compliant with generic API interfaces
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
