### PR TITLE
pagination fixes in generic client

### DIFF
--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -120,13 +120,15 @@ func ExampleAPI_listPaged() {
 	// list all backends, with 10 entries per page and starting on first page.
 	b := backend.Backend{}
 	var pageIter types.PageInfo
-	if err := apiClient.List(context.TODO(), &b, Paged(0, 10, &pageIter)); err != nil {
+	if err := apiClient.List(context.TODO(), &b, Paged(1, 10, &pageIter)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)
 	} else {
 		var backends []backend.Backend
 		for pageIter.Next(&backends) {
+			fmt.Printf("Listing entries on page %v\n", pageIter.CurrentPage())
+
 			for _, backend := range backends {
-				fmt.Printf("Got backend named \"%v\"\n", backend.Name)
+				fmt.Printf("  Got backend named \"%v\"\n", backend.Name)
 			}
 		}
 
@@ -135,11 +137,15 @@ func ExampleAPI_listPaged() {
 			// Errors will prevent pageIter.Next() to continue, you can call pageIter.ResetError() to resume.
 			fmt.Printf("Error while iterating pages of backends: %v\n", err)
 		}
+
+		fmt.Printf("Last page listed was page %v, which returned %v entries\n", pageIter.CurrentPage(), len(backends))
 	}
 
 	// Output:
-	// Got backend named "Example-Backend"
-	// Got backend named "backend-01"
+	// Listing entries on page 1
+	//   Got backend named "Example-Backend"
+	//   Got backend named "backend-01"
+	// Last page listed was page 2, which returned 0 entries
 }
 
 func ExampleAPI_listChannel() {

--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -120,7 +120,7 @@ func ExampleAPI_listPaged() {
 	// list all backends, with 10 entries per page and starting on first page.
 	b := backend.Backend{}
 	var pageIter types.PageInfo
-	if err := apiClient.List(context.TODO(), &b, Paged(1, 10, &pageIter)); err != nil {
+	if err := apiClient.List(context.TODO(), &b, Paged(1, 2, &pageIter)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)
 	} else {
 		var backends []backend.Backend
@@ -145,7 +145,13 @@ func ExampleAPI_listPaged() {
 	// Listing entries on page 1
 	//   Got backend named "Example-Backend"
 	//   Got backend named "backend-01"
-	// Last page listed was page 2, which returned 0 entries
+	// Listing entries on page 2
+	//   Got backend named "test-backend-01"
+	//   Got backend named "test-backend-02"
+	// Listing entries on page 3
+	//   Got backend named "test-backend-03"
+	//   Got backend named "test-backend-04"
+	// Last page listed was page 4, which returned 0 entries
 }
 
 func ExampleAPI_listChannel() {
@@ -172,6 +178,8 @@ func ExampleAPI_listChannel() {
 
 	// Output:
 	// Got backend named "Example-Backend"
+	// Got backend named "test-backend-02"
+	// Got backend named "test-backend-04"
 }
 
 func ExampleAPI_update() {

--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -193,8 +193,12 @@ func (a defaultAPI) List(ctx context.Context, o types.FilterObject, opts ...type
 
 			for pi.Next(&pageData) {
 				for _, o := range pageData {
+					// since we are in a goroutine, we might already be in the next iteration of this loop
+					// at the time the receiving end of this channel calls the closure. Having a loop-body
+					// scoped variables makes the data for the closure perfectly identified.
+					closureData := o
 					c <- func(out types.Object) error {
-						return json.Unmarshal(o, out)
+						return json.Unmarshal(closureData, out)
 					}
 				}
 			}

--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -145,7 +145,14 @@ func (a defaultAPI) List(ctx context.Context, o types.FilterObject, opts ...type
 	}
 
 	if options.Paged {
-		addPaginationQueryParameters(ctx, req, options)
+		if options.Page == 0 {
+			log := logr.FromContextOrDiscard(ctx)
+			log.V(1).Info("List called requesting page 0, fixing to page 1")
+
+			options.Page = 1
+		}
+
+		addPaginationQueryParameters(req, options)
 	}
 
 	result := json.RawMessage{}
@@ -407,14 +414,7 @@ func getResponseType(res *http.Response) (string, error) {
 	return "application/json", nil
 }
 
-func addPaginationQueryParameters(ctx context.Context, req *http.Request, opts types.ListOptions) {
-	if opts.Page == 0 {
-		log := logr.FromContextOrDiscard(ctx)
-		log.V(1).Info("List called requesting page 0, fixing to page 1")
-
-		opts.Page = 1
-	}
-
+func addPaginationQueryParameters(req *http.Request, opts types.ListOptions) {
 	query := req.URL.Query()
 	query.Add("page", strconv.FormatUint(uint64(opts.Page), 10))
 	query.Add("limit", strconv.FormatUint(uint64(opts.EntriesPerPage), 10))

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -398,7 +398,14 @@ var _ = Describe("creating API with different options", func() {
 	})
 
 	It("handles users trying to list page 0", func() {
-		server.AppendHandlers(ghttp.RespondWithJSONEncoded(200, []string{}))
+		server.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.RespondWithJSONEncoded(200, []string{}),
+				func(res http.ResponseWriter, req *http.Request) {
+					Expect(req.URL.Query().Get("page")).To(Equal("1"))
+				},
+			),
+		)
 
 		log := strings.Builder{}
 

--- a/pkg/api/mockserver_test.go
+++ b/pkg/api/mockserver_test.go
@@ -59,6 +59,32 @@ func newMockServer() *ghttp.Server {
 			Identifier: "bogus identifier 3",
 			Mode:       lbaasCommon.TCP,
 		},
+		{
+			Name:       "test-backend-01",
+			Identifier: "test identifier 1",
+			Mode:       lbaasCommon.TCP,
+		},
+		{
+			Name:       "test-backend-02",
+			Identifier: "test identifier 2",
+			Mode:       lbaasCommon.TCP,
+			LoadBalancer: loadbalancer.LoadBalancerInfo{
+				Identifier: "bogus identifier 2",
+			},
+		},
+		{
+			Name:       "test-backend-03",
+			Identifier: "test identifier 3",
+			Mode:       lbaasCommon.TCP,
+		},
+		{
+			Name:       "test-backend-04",
+			Identifier: "test identifier 4",
+			Mode:       lbaasCommon.TCP,
+			LoadBalancer: loadbalancer.LoadBalancerInfo{
+				Identifier: "bogus identifier 2",
+			},
+		},
 	}
 
 	const backendBasePath = "/api/LBaaS/v1/backend.json"
@@ -107,13 +133,11 @@ func newMockServer() *ghttp.Server {
 
 		if limit > 0 {
 			idxStart := (page - 1) * limit
+			idxEnd := idxStart + limit
 
 			if idxStart >= len(ret) {
 				ret = make([]backend.Backend, 0)
 			} else {
-
-				idxEnd := idxStart + limit
-
 				if idxEnd > len(ret) {
 					idxEnd = len(ret)
 				}

--- a/pkg/api/pagination.go
+++ b/pkg/api/pagination.go
@@ -211,6 +211,10 @@ func decodePaginationResponseBody(data json.RawMessage, opts types.ListOptions) 
 	// First dataData then data is important since we switch over the index of the decoded message,
 	// set data from dataData and fallthrough.
 	// The entries have to be pointers, else every entry matches every data - since it is an interface{} then.
+	//
+	// TODO(@LittleFox94): are there actually paginated APIs returning only an Array without any page metadata?
+	// I was sure there was one, but cannot find one right now and maybe "plain array returned" is already the
+	// info "don't even try to get the next page".
 	responseTypes := []interface{}{&dataDataResponse{}, &dataResponse{}, &[]json.RawMessage{}}
 	actualResponse := -1
 

--- a/pkg/api/pagination_test.go
+++ b/pkg/api/pagination_test.go
@@ -29,7 +29,10 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 	JustBeforeEach(func() {
 		returnedErrors := 0
 
+		expectedPage := 2
 		fetcher := func(page uint) (json.RawMessage, error) {
+			Expect(page).To(BeEquivalentTo(expectedPage))
+
 			if page > uint(len(responses)) {
 				return json.RawMessage("[]"), nil
 			}
@@ -45,8 +48,11 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 				case 3:
 					return json.RawMessage(`[{ "error": "random garbage data returned" }]`), nil
 				case 4:
+					expectedPage++
 					return afterErrorResponse, nil
 				}
+			} else {
+				expectedPage++
 			}
 
 			return responses[page-1], nil
@@ -77,6 +83,7 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 
 			Expect(ok).To(BeFalse())
 			Expect(err).To(MatchError(ErrTypeNotSupported))
+			Expect(pi.CurrentPage()).To(BeEquivalentTo(0))
 		})
 
 		It("iterates through the pages until first error", func() {
@@ -91,7 +98,9 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 			}
 
 			Expect(page).To(BeEquivalentTo(1))
-			Expect(pi.CurrentPage()).To(BeEquivalentTo(2))
+
+			// pi still reports page 1 because that's the data in out
+			Expect(pi.CurrentPage()).To(BeEquivalentTo(1))
 
 			// This is the data of the first page. With the fetcher returning an error, this data
 			// is not overwritten even though we already are on second page. We can use this behavior


### PR DESCRIPTION
### Description

CurrentPage() is expected to return the page currently retrieved, which page the data in the passed array belongs to. Update test to reflect that.

currentPage was incremented before doing the API request, meaning it returned the page last tried to be retrieved instead of the last one retrieved successfully. Now currentPage+1 is requested and currentPage is incremented on success.

Add check for query argument page != 0 in pagination test.

Also fixes a bad data race when listing objects using a channel.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE (fixes for unreleased code)
```

### References

Introduced in #56

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
