### PR TITLE
Allow objects to disable paginated List operations

### DIFF
--- a/pkg/api/pagination_test.go
+++ b/pkg/api/pagination_test.go
@@ -68,7 +68,7 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 			EntriesPerPage: 2,
 		}
 
-		pi, piCreateError = newPageIter(context.TODO(), responseBody, opts, fetcher)
+		pi, piCreateError = newPageIter(context.TODO(), responseBody, opts, fetcher, false)
 	})
 
 	AssertCommonBehavior := func() {

--- a/pkg/api/types/object.go
+++ b/pkg/api/types/object.go
@@ -43,3 +43,10 @@ type ResponseFilterHook interface {
 	// FilterAPIResponse is called after a response from the engine regarding this object is received. Instead of the original response, the one returned by this function is decoded.
 	FilterAPIResponse(op Operation, options Options, res *http.Response) (*http.Response, error)
 }
+
+// PaginationSupportHook is an interface Objects can optionally implement to enable or disable pagination support for List operations.
+type PaginationSupportHook interface {
+	// Returns if the API supports pagination for List operations. Mind optionally supported filters in EndpointURL, which may go to different API endpoints which independently might
+	// or might not support pagination.
+	HasPagination(ctx context.Context, options Options) (bool, error)
+}


### PR DESCRIPTION
### Description

Some API endpoints do not support pagination, ignoring the query argument and just returning all data all the time - making the pageIter and objectchannel return all data in an endless loop over and over again.

This hook allows objects to configure if they support paginated list operations, even dynamically if they support only when some filters are (not) set or something.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE (part of generic client which isn't released yet)
```

### References

Needs fixes from #68 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
