### PR TITLE
Allow UUID identifiers in generic client

### DIFF
--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"context"
+	"net/url"
+
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type api_test_nonstruct_object bool
+
+func (o *api_test_nonstruct_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+type api_test_nonpointer_object bool
+
+func (o api_test_nonpointer_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+type api_test_noident_object struct {
+	Value string `json:"value"`
+}
+
+func (o api_test_noident_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+type api_test_invalidident_object struct {
+	Value int `json:"value" anxcloud:"identifier"`
+}
+
+func (o api_test_invalidident_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+type api_test_uuidident_object struct {
+	Identifier uuid.UUID `json:"identifier" anxcloud:"identifier"`
+}
+
+func (o api_test_uuidident_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/invalid_anyway")
+}
+
+var _ = Describe("getObjectIdentifier function", func() {
+	It("errors out on invalid Object types", func() {
+		nso := api_test_nonstruct_object(false)
+		identifier, err := getObjectIdentifier(&nso, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("must be implemented as structs"))
+		Expect(identifier).To(BeEmpty())
+
+		npo := api_test_nonpointer_object(false)
+		identifier, err = getObjectIdentifier(npo, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("must be implemented on a pointer to struct"))
+		Expect(identifier).To(BeEmpty())
+
+		nio := api_test_noident_object{"invalid"}
+		identifier, err = getObjectIdentifier(&nio, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("lacks identifier field"))
+		Expect(identifier).To(BeEmpty())
+
+		iio := api_test_invalidident_object{32}
+		identifier, err = getObjectIdentifier(&iio, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("identifier field has an unsupported type"))
+		Expect(identifier).To(BeEmpty())
+	})
+
+	It("accepts valid Object types", func() {
+		sio := api_test_object{"identifier"}
+		identifier, err := getObjectIdentifier(&sio, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(identifier).To(Equal("identifier"))
+
+		uio := api_test_uuidident_object{uuid.FromStringOrNil("6010622e-3e14-11ec-a5c3-0f457821b3ba")}
+		identifier, err = getObjectIdentifier(&uio, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(identifier).To(Equal("6010622e-3e14-11ec-a5c3-0f457821b3ba"))
+	})
+
+	Context("when doing an operation on a specific object", func() {
+		It("errors out on valid Object type but empty identifier", func() {
+			o := api_test_object{""}
+			identifier, err := getObjectIdentifier(&o, true)
+			Expect(err).To(MatchError(ErrUnidentifiedObject))
+			Expect(identifier).To(BeEmpty())
+		})
+
+		It("returns the correct identifier", func() {
+			o := api_test_object{"test"}
+			identifier, err := getObjectIdentifier(&o, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(identifier).To(Equal("test"))
+		})
+	})
+})

--- a/pkg/api/types/object.go
+++ b/pkg/api/types/object.go
@@ -9,7 +9,8 @@ import (
 // Object is the interface all objects to be retrieved by the generic API client are required to implement.
 //
 // On top of implementing this interface, an Object is always implemented as a struct, the pointer to it is what is passed to the generic API client.
-// These Object structs need to have a string member with `anxcloud:"identifier"` tag on it.
+// These Object structs need to have a member with `anxcloud:"identifier"` tag on it. Only strings and "github.com/satori/go.uuid".UUID identifiers
+// are supported for now (look in pkg/api/object.go_getObjectIdentifier for code specifying the allowed types).
 type Object interface {
 	// Returns the URL to retrieve resources of the given type from or an error.
 	// The request URL is formed of `client.BaseURL() + first return value of this function`, requests for a single object get


### PR DESCRIPTION
### Description

This PR adds support for "github.com/satori/go.uuid".UUID Object identifiers in generic client.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE (updates non-releases functionality)
```

### References

Generic client introduced in #56

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
