### PR TITLE
✨: allow Object identifiers in embedded fields

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -26,6 +26,15 @@ var (
 	// ErrTypeNotSupported is returned when an argument is of type interface{}, manual type checking via reflection is done and the given arguments type cannot be used.
 	ErrTypeNotSupported = errors.New("the given type cannot be used for the requested operation")
 
+	// ErrObjectWithoutIdentifier is a specialized ErrTypeNotSupport for Objects not having a fields tagged with `anxcloud:"identifier"`.
+	ErrObjectWithoutIdentifier = fmt.Errorf("%w: Object lacks identifier field", ErrTypeNotSupported)
+
+	// ErrObjectWithMultipleIdentifier is a specialized ErrTypeNotSupport for Objects having multiple fields tagged with `anxcloud:"identifier"`.
+	ErrObjectWithMultipleIdentifier = fmt.Errorf("%w: Object has multiple fields tagged as identifier", ErrTypeNotSupported)
+
+	// ErrObjectIdentifierTypeNotSupported is a specialized ErrTypeNotSupport for Objects having a field tagged with `anxcloud:"identifier"` with an unsupported type.
+	ErrObjectIdentifierTypeNotSupported = fmt.Errorf("%w: Objects identifier field has an unsupported type", ErrTypeNotSupported)
+
 	// ErrContextRequired is returned when a nil context was passed as argument.
 	ErrContextRequired = errors.New("no context given")
 )

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -45,8 +46,10 @@ fields:
 					if returnIdentifier == nil {
 						returnIdentifier = &ret
 					} else {
-						return "", fmt.Errorf("%w: Objects need to have exactly one identifier (type %v has multiple fields tagged as identifier)", ErrTypeNotSupported, t)
+						return "", fmt.Errorf("%w (type %v has multiple fields tagged as identifier)", ErrObjectWithMultipleIdentifier, t)
 					}
+				} else if errors.Is(err, ErrObjectWithMultipleIdentifier) || errors.Is(err, ErrObjectIdentifierTypeNotSupported) {
+					return "", err
 				}
 			}
 
@@ -77,12 +80,12 @@ fields:
 
 							continue fields
 						} else {
-							return "", fmt.Errorf("%w: Objects need to have exactly one identifier (type %v has multiple fields tagged as identifier)", ErrTypeNotSupported, t)
+							return "", fmt.Errorf("%w (type %v has multiple fields tagged as identifier)", ErrObjectWithMultipleIdentifier, t)
 						}
 					}
 				}
 
-				return "", fmt.Errorf("%w: Objects identifier field has an unsupported type (type %v has an identifier of type %v)", ErrTypeNotSupported, t, field.Type)
+				return "", fmt.Errorf("%w (type %v has an identifier of type %v)", ErrObjectIdentifierTypeNotSupported, t, field.Type)
 			}
 		}
 	}
@@ -91,5 +94,5 @@ fields:
 		return *returnIdentifier, nil
 	}
 
-	return "", fmt.Errorf("%w: Object lacks identifier field (type %v does not have a field with `anxcloud:\"identifier\"` tag)", ErrTypeNotSupported, t)
+	return "", fmt.Errorf("%w (type %v does not have a field with `anxcloud:\"identifier\"` tag)", ErrObjectWithoutIdentifier, t)
 }

--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -48,6 +48,19 @@ func (o api_test_uuidident_object) EndpointURL(ctx context.Context, op types.Ope
 	return url.Parse("/invalid_anyway")
 }
 
+type api_test_embeddedident_object struct {
+	api_test_object
+}
+
+type api_test_ptrembeddedident_object struct {
+	*api_test_object
+}
+
+type api_test_multiembeddedident_object struct {
+	uuid.UUID
+	api_test_object
+}
+
 var _ = Describe("getObjectIdentifier function", func() {
 	It("errors out on invalid Object types", func() {
 		nso := api_test_nonstruct_object(false)
@@ -85,6 +98,23 @@ var _ = Describe("getObjectIdentifier function", func() {
 		identifier, err = getObjectIdentifier(&uio, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(identifier).To(Equal("6010622e-3e14-11ec-a5c3-0f457821b3ba"))
+	})
+
+	It("accepts valid Object types where the identifier is in embedded fields", func() {
+		eio := api_test_embeddedident_object{api_test_object{"identifier"}}
+		identifier, err := getObjectIdentifier(&eio, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(identifier).To(Equal("identifier"))
+
+		peio := api_test_ptrembeddedident_object{&api_test_object{"identifier"}}
+		identifier, err = getObjectIdentifier(&peio, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(identifier).To(Equal("identifier"))
+
+		meio := api_test_multiembeddedident_object{uuid.NewV4(), api_test_object{"identifier"}}
+		identifier, err = getObjectIdentifier(&meio, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(identifier).To(Equal("identifier"))
 	})
 
 	Context("when doing an operation on a specific object", func() {

--- a/pkg/api/object_test.go
+++ b/pkg/api/object_test.go
@@ -61,6 +61,15 @@ type api_test_multiembeddedident_object struct {
 	api_test_object
 }
 
+type api_test_multiident_object struct {
+	Identifier  string `json:"identifier" anxcloud:"identifier"`
+	Identifier2 string `json:"identifier2" anxcloud:"identifier"`
+}
+
+func (o api_test_multiident_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	return url.Parse("/resource/v1")
+}
+
 var _ = Describe("getObjectIdentifier function", func() {
 	It("errors out on invalid Object types", func() {
 		nso := api_test_nonstruct_object(false)
@@ -85,6 +94,12 @@ var _ = Describe("getObjectIdentifier function", func() {
 		identifier, err = getObjectIdentifier(&iio, false)
 		Expect(err).To(MatchError(ErrTypeNotSupported))
 		Expect(err.Error()).To(ContainSubstring("identifier field has an unsupported type"))
+		Expect(identifier).To(BeEmpty())
+
+		mio := api_test_multiident_object{"identifier", "identifier2"}
+		identifier, err = getObjectIdentifier(&mio, false)
+		Expect(err).To(MatchError(ErrTypeNotSupported))
+		Expect(err.Error()).To(ContainSubstring("api_test_multiident_object has multiple fields tagged as identifier"))
 		Expect(identifier).To(BeEmpty())
 	})
 


### PR DESCRIPTION
### Description

This extends `getObjectIdentifier` to recursively search for identifier field in embedded/anonymous fields, too.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE (addition to unreleased feature)
```

### References

Generic client introduced in #56

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
