### PR TITLE
SYSENG-686 ✨: Introduce ResponseDecodeHook for manipulating returned objects

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -149,12 +150,12 @@ func (o *api_test_object) HasPagination(ctx context.Context, opts types.Options)
 	return o.Val != "no_pagination", nil
 }
 
-func (o *api_test_object) DecodeAPIResponse(data *json.RawMessage, url *url.URL, op types.Operation, opts types.Options) error {
+func (o *api_test_object) DecodeAPIResponse(ctx context.Context, data io.Reader) error {
 	if o.Val == "failing_decode_response" {
 		return api_test_error
 	}
 
-	return json.Unmarshal(*data, o)
+	return json.NewDecoder(data).Decode(o)
 }
 
 type api_test_error_roundtripper bool

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -52,7 +52,7 @@ func OptionsFromContext(ctx context.Context) (types.Options, error) {
 // This is set on every context passed by the generic client to Object functions _after_ the
 // call to EndpointURL.
 func URLFromContext(ctx context.Context) (url.URL, error) {
-	if op, ok := ctx.Value(contextKeyOperation).(url.URL); ok {
+	if op, ok := ctx.Value(contextKeyURL).(url.URL); ok {
 		return op, nil
 	}
 

--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+type contextKey string
+
+const (
+	contextKeyOperation contextKey = "operation"
+	contextKeyOptions   contextKey = "options"
+	contextKeyURL       contextKey = "url"
+)
+
+func contextWithOperation(ctx context.Context, op types.Operation) context.Context {
+	return context.WithValue(ctx, contextKeyOperation, op)
+}
+
+func contextWithOptions(ctx context.Context, opts types.Options) context.Context {
+	return context.WithValue(ctx, contextKeyOptions, opts)
+}
+
+func contextWithURL(ctx context.Context, url url.URL) context.Context {
+	return context.WithValue(ctx, contextKeyURL, url)
+}
+
+// OperationFromContext returns the current generic client operation from a given context.
+// This is set on every context passed by the generic client to Object functions.
+func OperationFromContext(ctx context.Context) (types.Operation, error) {
+	if op, ok := ctx.Value(contextKeyOperation).(types.Operation); ok {
+		return op, nil
+	}
+
+	return "", ErrContextKeyNotSet
+}
+
+// OptionsFromContext returns the Options for the current generic client operation.
+// This is set on every context passed by the generic client to Object functions.
+func OptionsFromContext(ctx context.Context) (types.Options, error) {
+	if op, ok := ctx.Value(contextKeyOptions).(types.Options); ok {
+		return op, nil
+	}
+
+	return nil, ErrContextKeyNotSet
+}
+
+// URLFromContext returns the url originally returned from the Objects EndpointURL method for
+// the current generic client operation.
+// This is set on every context passed by the generic client to Object functions _after_ the
+// call to EndpointURL.
+func URLFromContext(ctx context.Context) (url.URL, error) {
+	if op, ok := ctx.Value(contextKeyOperation).(url.URL); ok {
+		return op, nil
+	}
+
+	return url.URL{}, ErrContextKeyNotSet
+}

--- a/pkg/api/context_test.go
+++ b/pkg/api/context_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+	"github.com/anexia-it/go-anxcloud/pkg/client"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+type context_test_object struct {
+	Test string `anxcloud:"identifier"`
+}
+
+func (o *context_test_object) EndpointURL(ctx context.Context, op types.Operation, opts types.Options) (*url.URL, error) {
+	switch o.Test {
+	case "Operation":
+		Expect(OperationFromContext(ctx)).To(Equal(op))
+	case "Options":
+		Expect(OptionsFromContext(ctx)).To(Equal(opts))
+	case "URL":
+		u, err := URLFromContext(ctx)
+		Expect(err).To(MatchError(ErrContextKeyNotSet))
+		Expect(u).To(BeNil())
+	default:
+		Fail(fmt.Sprintf("Unknown property to test: %v", o.Test))
+	}
+
+	return url.Parse("/")
+}
+
+var _ = Describe("context passed to Object methods", func() {
+	var server *ghttp.Server
+	var api API
+	var ctx context.Context
+
+	JustBeforeEach(func() {
+		ctx = context.TODO()
+
+		server = ghttp.NewServer()
+		a, err := NewAPI(WithClientOptions(
+			client.IgnoreMissingToken(),
+			client.BaseURL(server.URL()),
+		))
+
+		Expect(err).NotTo(HaveOccurred())
+		api = a
+	})
+
+	It("has operation in context for every method call", func() {
+		o := context_test_object{"Operation"}
+
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", fmt.Sprintf("/%v", o.Test)),
+			ghttp.RespondWithJSONEncoded(200, o),
+		))
+
+		err := api.Get(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("has options in context for every method call", func() {
+		o := context_test_object{"Options"}
+
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", fmt.Sprintf("/%v", o.Test)),
+			ghttp.RespondWithJSONEncoded(200, o),
+		))
+
+		err := api.Get(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("has URL in context for every method call except EndpointURL", func() {
+		o := context_test_object{"Options"}
+
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", fmt.Sprintf("/%v", o.Test)),
+			ghttp.RespondWithJSONEncoded(200, o),
+		))
+
+		err := api.Get(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -37,6 +37,9 @@ var (
 
 	// ErrContextRequired is returned when a nil context was passed as argument.
 	ErrContextRequired = errors.New("no context given")
+
+	// ErrContextKeyNotSet is returned when trying to retrieve an unset value from a context.
+	ErrContextKeyNotSet = errors.New("requested context key is not set")
 )
 
 // EngineError is the base type for all errors returned by the engine.

--- a/pkg/api/pagination.go
+++ b/pkg/api/pagination.go
@@ -114,15 +114,21 @@ func (p *pageIter) Next(objects interface{}) bool {
 		return false
 	}
 
-	d := json.NewDecoder(bytes.NewBuffer(data))
-	d.DisallowUnknownFields()
+	newVal := reflect.MakeSlice(val.Type().Elem(), len(data), len(data))
 
-	// TODO: The DecodeAPIResponse hook needs to be applied to the single Objects
-	if err := d.Decode(objects); err != nil {
-		p.errRetryCounter++
-		p.err = err
-		return false
+	for i, e := range data {
+		decodeInto := newVal.Index(i).Addr().Interface()
+
+		err = decodeResponse(p.ctx, "application/json", bytes.NewBuffer(e), decodeInto)
+
+		if err != nil {
+			p.errRetryCounter++
+			p.err = err
+			return false
+		}
 	}
+
+	val.Elem().Set(newVal)
 
 	log := logr.FromContextOrDiscard(p.ctx)
 
@@ -165,7 +171,7 @@ func newPageIter(ctx context.Context, responseBody json.RawMessage, opts types.L
 		singlePageMode: singlePageMode,
 	}
 
-	currentPage, limit, totalPages, totalItems, data, err := decodePaginationResponseBody(responseBody, opts)
+	currentPage, limit, totalPages, totalItems, _, err := decodePaginationResponseBody(responseBody, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -183,18 +189,17 @@ func newPageIter(ctx context.Context, responseBody json.RawMessage, opts types.L
 	// use the pageFetcher provided as argument
 	ret.pageFetcher = func(page uint) (json.RawMessage, error) {
 		ret.pageFetcher = fetcher
-		return data, nil
+		return responseBody, nil
 	}
 
 	return &ret, nil
 }
 
-func decodePaginationResponseBody(data json.RawMessage, opts types.ListOptions) (page, limit, totalPages, totalItems uint, ret json.RawMessage, err error) {
+func decodePaginationResponseBody(data json.RawMessage, opts types.ListOptions) (page, limit, totalPages, totalItems uint, ret []json.RawMessage, err error) {
 	page = 0
 	limit = 0
 	totalPages = 0
 	totalItems = 0
-	ret = json.RawMessage{}
 
 	// TODO(LittleFox94): this is not the same for every API and we need a way to override this or
 	// find the X ways it's done and have options for that. Currently we support those two types and
@@ -206,7 +211,7 @@ func decodePaginationResponseBody(data json.RawMessage, opts types.ListOptions) 
 		TotalItems     uint `json:"total_items"`
 		EntriesPerPage uint `json:"limit"`
 
-		Data json.RawMessage `json:"data"`
+		Data []json.RawMessage `json:"data"`
 	}
 
 	type dataDataResponse struct {
@@ -249,7 +254,7 @@ func decodePaginationResponseBody(data json.RawMessage, opts types.ListOptions) 
 		fallthrough
 	case 1:
 		data := responseTypes[1].(*dataResponse)
-		page = data.CurrentPage - 1 // Next increments the page before trying to retrieve it
+		page = data.CurrentPage
 		limit = data.EntriesPerPage
 		totalPages = data.TotalPages
 		totalItems = data.TotalItems
@@ -258,7 +263,7 @@ func decodePaginationResponseBody(data json.RawMessage, opts types.ListOptions) 
 		page = opts.Page
 		limit = opts.EntriesPerPage
 
-		ret, err = json.Marshal(responseTypes[2])
+		ret = *(responseTypes[2].(*[]json.RawMessage))
 	}
 
 	return page, limit, totalPages, totalItems, ret, err

--- a/pkg/api/pagination.go
+++ b/pkg/api/pagination.go
@@ -117,6 +117,7 @@ func (p *pageIter) Next(objects interface{}) bool {
 	d := json.NewDecoder(bytes.NewBuffer(data))
 	d.DisallowUnknownFields()
 
+	// TODO: The DecodeAPIResponse hook needs to be applied to the single Objects
 	if err := d.Decode(objects); err != nil {
 		p.errRetryCounter++
 		p.err = err

--- a/pkg/api/types/object.go
+++ b/pkg/api/types/object.go
@@ -2,7 +2,7 @@ package types
 
 import (
 	"context"
-	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -53,5 +53,5 @@ type PaginationSupportHook interface {
 }
 
 type ResponseDecodeHook interface {
-	DecodeAPIResponse(data *json.RawMessage, url *url.URL, op Operation, options Options) error
+	DecodeAPIResponse(ctx context.Context, data io.Reader) error
 }

--- a/pkg/api/types/object.go
+++ b/pkg/api/types/object.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/url"
 )
@@ -49,4 +50,8 @@ type PaginationSupportHook interface {
 	// Returns if the API supports pagination for List operations. Mind optionally supported filters in EndpointURL, which may go to different API endpoints which independently might
 	// or might not support pagination.
 	HasPagination(ctx context.Context, options Options) (bool, error)
+}
+
+type ResponseDecodeHook interface {
+	DecodeAPIResponse(data *json.RawMessage, url *url.URL, op Operation, options Options) error
 }


### PR DESCRIPTION
### Description

This adds the ResponseDecodeHook as discussed in SYSENG-686.

Using this hook, an Object can have completely custom decoding, matching the already existing `RequestBodyHook`. The Object is required to decode the data in the given `io.Reader` into the receiver, storing the decoded data into itself.

To implement this with non-redundant code, the logic to decode an Object is exported into it's own function, used by all parts of the generic client (`api_implementation.go/doRequest()`, `api_implementation.go/List()/channel goroutine function` and `pagination.go/Next()`).

While implementing this new hook, we realized many arguments passed to the hook functions are actually kind of "the context". Because of this, we extended the context used by the generic client to include the `Operation`, `Options` and, after `EndpointURL` was called, the original URL. We plan to change the existing Hook functions to grab this information from the context instead of arguments.
Using a context allows us to add more to it, without having to change all the existing hooks.

This is a team effort of @toothstone and @LittleFox94 :muscle: 

### References

* #56 introduction of generic API client

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):

```release-note
NONE (additions to unreleased code)
```
