### PR TITLE
✅💚: vsphere: search good template for tests

### DIFF
--- a/tests/e2e_suite_test.go
+++ b/tests/e2e_suite_test.go
@@ -18,6 +18,8 @@ const (
 func init() {
 	test.RunAsIntegrationTest = true
 	test.InitFlags()
+
+	vsphereTestInit()
 }
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
### Description

Previously there was a template ID hardcoded in the tests, we now have a Name hardcoded and list all templates, selecting one that matches the name (always using the lexically highest build-string).

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE (tests updated)
```

### References

The CI runs failed today.

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
