### PR TITLE
Generic client: handle empty response bodies

### DIFF
--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -362,11 +362,15 @@ func (a defaultAPI) doRequest(req *http.Request, obj types.Object, body interfac
 		return err
 	}
 
-	if mediaType, err := getResponseType(response); err == nil {
-		return decodeResponse(req.Context(), mediaType, response.Body, body)
-	} else {
-		return err
+	if response.StatusCode != http.StatusNoContent {
+		if mediaType, err := getResponseType(response); err == nil {
+			return decodeResponse(req.Context(), mediaType, response.Body, body)
+		} else {
+			return err
+		}
 	}
+
+	return nil
 }
 
 func (a defaultAPI) contextPrepare(ctx context.Context, o types.Object, op types.Operation, opts types.Options) (context.Context, error) {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -401,7 +401,7 @@ var _ = Describe("creating API with different options", func() {
 	})
 
 	It("handles the Engine returning a weird response content-type", func() {
-		server.AppendHandlers(ghttp.RespondWith(200, nil, http.Header{"Content-Type": []string{"application/octet-stream"}}))
+		server.AppendHandlers(ghttp.RespondWith(200, "randomgarbage", http.Header{"Content-Type": []string{"application/octet-stream"}}))
 
 		api, err := NewAPI(
 			WithClientOptions(
@@ -414,6 +414,22 @@ var _ = Describe("creating API with different options", func() {
 		o := api_test_object{"identifier"}
 		err = api.Get(context.TODO(), &o)
 		Expect(err).To(MatchError(ErrUnsupportedResponseFormat))
+	})
+
+	It("does not crash on Engine responses without body", func() {
+		server.AppendHandlers(ghttp.RespondWith(204, nil))
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"identifier"}
+		err = api.Destroy(context.TODO(), &o)
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("handles the Engine returning bad responses for List requests", func() {


### PR DESCRIPTION
### Description

This PR allows the generic client to handle empty/missing response bodies.

### Release Note
```release-note
NONE (fix for unreleased generic client)
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
