### PR TITLE
📝: document List operations returning incomplete data

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,5 +25,7 @@ type API interface {
 	Destroy(context.Context, types.IdentifiedObject, ...DestroyOption) error
 
 	// List objects matching the info given in the object.
+	// Beware: listing endpoints usually do not return all data for an object, sometimes
+	// only the identifier is filled. This varies by specific API.
 	List(context.Context, types.FilterObject, ...ListOption) error
 }

--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -117,7 +117,10 @@ func ExampleAPI_listPaged() {
 	// see example on NewAPI how to implement this function
 	apiClient := newExampleAPI()
 
-	// list all backends, with 10 entries per page and starting on first page.
+	// List all backends, with 10 entries per page and starting on first page.
+
+	// Beware: listing endpoints usually do not return all data for an object, sometimes
+	// only the identifier is filled. This varies by specific API.
 	b := backend.Backend{}
 	var pageIter types.PageInfo
 	if err := apiClient.List(context.TODO(), &b, Paged(1, 2, &pageIter)); err != nil {
@@ -162,6 +165,9 @@ func ExampleAPI_listChannel() {
 
 	// list all backends using a channel and have the library handle the paging.
 	// Oh and we filter by LoadBalancer, because we can and the example has to be somewhere.
+
+	// Beware: listing endpoints usually do not return all data for an object, sometimes
+	// only the identifier is filled. This varies by specific API.
 	b := backend.Backend{LoadBalancer: loadbalancer.LoadBalancerInfo{Identifier: "bogus identifier 2"}}
 	if err := apiClient.List(context.TODO(), &b, AsObjectChannel(&channel)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)


### PR DESCRIPTION
### Description

Many API endpoints for listing resources only return a subset of data of a single object. This PR adds documentation in the two examples for listing (via PageInfo and via Channel) and on `API.List()`.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* NONE (doc update for unreleased feature)
```

### References
* generic client introduced in #56 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
