### PR TITLE
Add `FullObjects` option, retrieving full objects on listing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v1.2.0
-	github.com/go-logr/stdr v1.2.0 // indirect
+	github.com/go-logr/stdr v1.2.0
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.4
 	github.com/satori/go.uuid v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/anexia-it/go-anxcloud
 go 1.15
 
 require (
-	github.com/go-logr/logr v1.1.0
+	github.com/go-logr/logr v1.2.0
+	github.com/go-logr/stdr v1.2.0 // indirect
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.4
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-logr/logr v1.1.0 h1:nAbevmWlS2Ic4m4+/An5NXkaGqlqpbBgdcuThZxnZyI=
 github.com/go-logr/logr v1.1.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=
+github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/go-logr/logr v1.1.0 h1:nAbevmWlS2Ic4m4+/An5NXkaGqlqpbBgdcuThZxnZyI=
-github.com/go-logr/logr v1.1.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -26,6 +26,7 @@ type API interface {
 
 	// List objects matching the info given in the object.
 	// Beware: listing endpoints usually do not return all data for an object, sometimes
-	// only the identifier is filled. This varies by specific API.
+	// only the identifier is filled. This varies by specific API. If you need full objects,
+	// the FullObjects option might be your friend.
 	List(context.Context, types.FilterObject, ...ListOption) error
 }

--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -118,10 +118,11 @@ func ExampleAPI_listPaged() {
 	// List all backends, with 10 entries per page and starting on first page.
 
 	// Beware: listing endpoints usually do not return all data for an object, sometimes
-	// only the identifier is filled. This varies by specific API.
+	// only the identifier is filled. This varies by specific API. If you need full objects,
+	// the FullObjects option might be your friend. To test this option, we use it here.
 	b := lbaasv1.Backend{}
 	var pageIter types.PageInfo
-	if err := apiClient.List(context.TODO(), &b, Paged(1, 2, &pageIter)); err != nil {
+	if err := apiClient.List(context.TODO(), &b, Paged(1, 2, &pageIter), FullObjects(true)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)
 	} else {
 		var backends []lbaasv1.Backend
@@ -129,7 +130,9 @@ func ExampleAPI_listPaged() {
 			fmt.Printf("Listing entries on page %v\n", pageIter.CurrentPage())
 
 			for _, backend := range backends {
-				fmt.Printf("  Got backend named \"%v\"\n", backend.Name)
+				// backend.Mode is only filled when the full object is retrieved, we can only use it here because
+				// we added the FullObjects(true) option to the List() call above.
+				fmt.Printf("  Got backend named \"%v\" with mode \"%v\"\n", backend.Name, backend.Mode)
 			}
 		}
 
@@ -144,14 +147,14 @@ func ExampleAPI_listPaged() {
 
 	// Output:
 	// Listing entries on page 1
-	//   Got backend named "Example-Backend"
-	//   Got backend named "backend-01"
+	//   Got backend named "Example-Backend" with mode "tcp"
+	//   Got backend named "backend-01" with mode "tcp"
 	// Listing entries on page 2
-	//   Got backend named "test-backend-01"
-	//   Got backend named "test-backend-02"
+	//   Got backend named "test-backend-01" with mode "tcp"
+	//   Got backend named "test-backend-02" with mode "tcp"
 	// Listing entries on page 3
-	//   Got backend named "test-backend-03"
-	//   Got backend named "test-backend-04"
+	//   Got backend named "test-backend-03" with mode "tcp"
+	//   Got backend named "test-backend-04" with mode "tcp"
 	// Last page listed was page 4, which returned 0 entries
 }
 
@@ -165,7 +168,8 @@ func ExampleAPI_listChannel() {
 	// Oh and we filter by LoadBalancer, because we can and the example has to be somewhere.
 
 	// Beware: listing endpoints usually do not return all data for an object, sometimes
-	// only the identifier is filled. This varies by specific API.
+	// only the identifier is filled. This varies by specific API. If you need full objects,
+	// the FullObjects option might be your friend.
 	b := lbaasv1.Backend{LoadBalancer: lbaasv1.LoadBalancer{Identifier: "bogus identifier 2"}}
 	if err := apiClient.List(context.TODO(), &b, ObjectChannel(&channel)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)
@@ -176,14 +180,18 @@ func ExampleAPI_listChannel() {
 				break
 			}
 
-			fmt.Printf("Got backend named \"%v\"\n", b.Name)
+			// b.Mode is only filled when the full object is retrieved since this attribute is
+			// not returned by the List API endpoint. To have it, we would have to either manually
+			// retrieve the full object or use the FullObjects option in the List call above.
+			// See the ListPaged example for the FullObjects option in action.
+			fmt.Printf("Got backend named \"%v\" with mode \"%v\"\n", b.Name, b.Mode)
 		}
 	}
 
 	// Output:
-	// Got backend named "Example-Backend"
-	// Got backend named "test-backend-02"
-	// Got backend named "test-backend-04"
+	// Got backend named "Example-Backend" with mode ""
+	// Got backend named "test-backend-02" with mode ""
+	// Got backend named "test-backend-04" with mode ""
 }
 
 func ExampleAPI_update() {

--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -194,7 +194,7 @@ func (a defaultAPI) List(ctx context.Context, o types.FilterObject, opts ...type
 			return response, nil
 		}
 
-		iter, err := newPageIter(ctx, result, options, fetcher, singlePageMode)
+		iter, err := newPageIter(ctx, a, result, options, fetcher, singlePageMode)
 		if err != nil {
 			return err
 		}
@@ -221,6 +221,12 @@ func (a defaultAPI) List(ctx context.Context, o types.FilterObject, opts ...type
 						err := decodeResponse(ctx, "application/json", bytes.NewBuffer(closureData), out)
 						if err != nil {
 							return err
+						}
+
+						if options.FullObjects {
+							if err := a.Get(ctx, out); err != nil {
+								return err
+							}
 						}
 
 						select {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -213,7 +213,7 @@ var _ = Describe("decodeResponse function", func() {
 	})
 })
 
-var _ = Describe("creating API with different options", func() {
+var _ = Describe("using an API object", func() {
 	var server *ghttp.Server
 
 	logger := stdr.New(log.New(GinkgoWriter, "", log.Ltime|log.Lshortfile|log.Lmsgprefix))
@@ -492,6 +492,219 @@ var _ = Describe("creating API with different options", func() {
 
 		err = api.List(context.TODO(), &o, Paged(1, 1, &pi))
 		Expect(err).To(MatchError(ErrPageResponseNotSupported))
+	})
+
+	Context("configured to use a mock server", func() {
+		type response struct {
+			status int
+			path   string
+			query  string
+			data   interface{}
+		}
+
+		var responses []response
+
+		var api API
+
+		JustBeforeEach(func() {
+			for _, r := range responses {
+				server.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", r.path, r.query),
+					ghttp.RespondWithJSONEncoded(r.status, r.data),
+				))
+			}
+
+			var err error
+			api, err = NewAPI(
+				WithLogger(logger),
+				WithClientOptions(
+					client.BaseURL(server.URL()),
+					client.IgnoreMissingToken(),
+				),
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		commonCheck := func(fullObjects bool) {
+			namePrefix := ""
+
+			if fullObjects {
+				namePrefix = "full "
+			}
+
+			It("returns correct data with List operation used with pagination", func() {
+				o := api_test_object{}
+
+				var pi types.PageInfo
+				// we use the same page size as for channel to make testing easier and to not have to
+				// provide the Paged option when using a channel
+				err := api.List(context.TODO(), &o, Paged(1, ListChannelDefaultPageSize, &pi), FullObjects(fullObjects))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pi.CurrentPage()).To(BeEquivalentTo(0))
+
+				var objects []api_test_object
+				for pi.Next(&objects) {
+					Expect(objects).To(HaveLen(2))
+
+					switch pi.CurrentPage() {
+					case 1:
+						Expect(objects).To(BeEquivalentTo([]api_test_object{
+							{namePrefix + "foo 1"},
+							{namePrefix + "foo 2"},
+						}))
+					case 2:
+						Expect(objects).To(BeEquivalentTo([]api_test_object{
+							{namePrefix + "foo 3"},
+							{namePrefix + "foo 4"},
+						}))
+					case 3:
+						Expect(objects).To(BeEquivalentTo([]api_test_object{}))
+					default:
+						Fail("Unexpected current page")
+					}
+				}
+
+				Expect(pi.Error()).NotTo(HaveOccurred())
+				Expect(pi.CurrentPage()).To(BeEquivalentTo(3))
+			})
+
+			It("returns correct data with List operation used with a channel", func() {
+				o := api_test_object{}
+
+				channel := make(types.ObjectChannel)
+				err := api.List(context.TODO(), &o, ObjectChannel(&channel), FullObjects(fullObjects))
+				Expect(err).NotTo(HaveOccurred())
+
+				i := 0
+				for retriever := range channel {
+					i++
+
+					err := retriever(&o)
+					Expect(err).NotTo(HaveOccurred())
+
+					switch i {
+					case 1:
+						Expect(o.Val).To(Equal(namePrefix + "foo 1"))
+					case 2:
+						Expect(o.Val).To(Equal(namePrefix + "foo 2"))
+					case 3:
+						Expect(o.Val).To(Equal(namePrefix + "foo 3"))
+					case 4:
+						Expect(o.Val).To(Equal(namePrefix + "foo 4"))
+					default:
+						Fail("Unexpected number of objects retrieved")
+					}
+				}
+			})
+		}
+
+		Context("FullObjects disabled", func() {
+			BeforeEach(func() {
+				responses = []response{
+					{200, "/resource/v1", "page=1&limit=10", []api_test_object{{"foo 1"}, {"foo 2"}}},
+					{200, "/resource/v1", "page=2&limit=10", []api_test_object{{"foo 3"}, {"foo 4"}}},
+					{200, "/resource/v1", "page=3&limit=10", []api_test_object{}},
+				}
+			})
+
+			commonCheck(false)
+		})
+
+		Context("FullObjects enabled", func() {
+			Context("requests all succeeding", func() {
+				BeforeEach(func() {
+					responses = []response{
+						{200, "/resource/v1", "page=1&limit=10", []api_test_object{{"foo 1"}, {"foo 2"}}},
+
+						{200, "/resource/v1/foo 1", "", api_test_object{"full foo 1"}},
+						{200, "/resource/v1/foo 2", "", api_test_object{"full foo 2"}},
+
+						{200, "/resource/v1", "page=2&limit=10", []api_test_object{{"foo 3"}, {"foo 4"}}},
+
+						{200, "/resource/v1/foo 3", "", api_test_object{"full foo 3"}},
+						{200, "/resource/v1/foo 4", "", api_test_object{"full foo 4"}},
+
+						{200, "/resource/v1", "page=3&limit=10", []api_test_object{}},
+					}
+				})
+
+				commonCheck(true)
+			})
+
+			Context("list request succeeding but get request failing", func() {
+				BeforeEach(func() {
+					responses = []response{
+						{200, "/resource/v1", "page=1&limit=10", []api_test_object{{"foo 1"}, {"foo 2"}}},
+
+						{400, "/resource/v1/foo 1", "", map[string]string{"error": "something went wrong"}}, // a very realistic error, sadly.
+					}
+				})
+
+				It("returns the error via page iterator", func() {
+					o := api_test_object{}
+
+					var pi types.PageInfo
+					err := api.List(context.TODO(), &o, Paged(1, 10, &pi), FullObjects(true))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pi.CurrentPage()).To(BeEquivalentTo(0))
+
+					var objects []api_test_object
+					Expect(pi.Next(&objects)).To(BeFalse())
+					Expect(pi.Error()).To(HaveOccurred())
+					Expect(pi.CurrentPage()).To(BeEquivalentTo(0))
+				})
+
+				It("returns the error via channel", func() {
+					o := api_test_object{}
+					ctx, cancel := context.WithCancel(context.TODO())
+
+					var c types.ObjectChannel
+					err := api.List(ctx, &o, ObjectChannel(&c), FullObjects(true))
+					Expect(err).NotTo(HaveOccurred())
+
+					retriever := <-c
+					Expect(retriever(&o)).To(HaveOccurred())
+					cancel()
+				})
+			})
+
+			Context("list request succeeding but decoding fails", func() {
+				BeforeEach(func() {
+					responses = []response{
+						{200, "/resource/v1", "page=1&limit=10", []api_test_object{{"foo 1"}, {"foo 2"}}},
+
+						{200, "/resource/v1/foo 1", "", "foo"},
+					}
+				})
+
+				It("returns the error via page iterator", func() {
+					o := api_test_object{}
+
+					var pi types.PageInfo
+					err := api.List(context.TODO(), &o, Paged(1, 10, &pi), FullObjects(true))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(pi.CurrentPage()).To(BeEquivalentTo(0))
+
+					var objects []api_test_object
+					Expect(pi.Next(&objects)).To(BeFalse())
+					Expect(pi.Error()).To(HaveOccurred())
+					Expect(pi.CurrentPage()).To(BeEquivalentTo(0))
+				})
+
+				It("returns the error via channel", func() {
+					o := api_test_object{}
+					ctx, cancel := context.WithCancel(context.TODO())
+
+					var c types.ObjectChannel
+					err := api.List(ctx, &o, ObjectChannel(&c), FullObjects(true))
+					Expect(err).NotTo(HaveOccurred())
+
+					retriever := <-c
+					Expect(retriever(&o)).To(HaveOccurred())
+					cancel()
+				})
+			})
+		})
 	})
 
 	It("handles users trying to list with page iterator and channel simultaneously", func() {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,7 @@ import (
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
+	"github.com/go-logr/stdr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
@@ -214,6 +216,9 @@ var _ = Describe("decodeResponse function", func() {
 var _ = Describe("creating API with different options", func() {
 	var server *ghttp.Server
 
+	logger := stdr.New(log.New(GinkgoWriter, "", log.Ltime|log.Lshortfile|log.Lmsgprefix))
+	stdr.SetVerbosity(3)
+
 	BeforeEach(func() {
 		server = ghttp.NewServer()
 	})
@@ -225,6 +230,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("barks when making a request while using a client with unparsable BaseURL", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL("as.lfdna,smdnasd:::"), // a keysmash, added ::: to have it a really unparsable URL
 				client.IgnoreMissingToken(),
@@ -299,6 +305,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles the Object returning an error on EndpointURL", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -316,6 +323,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles the Object returning an empty identifier on EndpointURL for operations requiring an IdentifiedObject", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -330,6 +338,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles the Object returning an error on FilterAPIRequest", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -344,6 +353,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles the Object returning an error on FilterAPIRequestBody", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -358,6 +368,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles the Object returning a request body that cannot be encoded in json on FilterAPIRequestBody", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -376,6 +387,7 @@ var _ = Describe("creating API with different options", func() {
 		server.SetAllowUnhandledRequests(true)
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -394,6 +406,7 @@ var _ = Describe("creating API with different options", func() {
 		)
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -410,6 +423,7 @@ var _ = Describe("creating API with different options", func() {
 		server.AppendHandlers(ghttp.RespondWith(200, "randomgarbage", http.Header{"Content-Type": []string{"application/octet-stream"}}))
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -426,6 +440,7 @@ var _ = Describe("creating API with different options", func() {
 		server.AppendHandlers(ghttp.RespondWith(204, nil))
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -447,6 +462,7 @@ var _ = Describe("creating API with different options", func() {
 		)
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -480,6 +496,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles users trying to list with page iterator and channel simultaneously", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -535,6 +552,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles the Object returning an error on HasPagination", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -555,6 +573,7 @@ var _ = Describe("creating API with different options", func() {
 		)
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),
@@ -686,6 +705,7 @@ var _ = Describe("creating API with different options", func() {
 		}
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.WithClient(&hc),
 				client.IgnoreMissingToken(),
@@ -700,6 +720,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles not being given a context", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.IgnoreMissingToken(),
 			),
@@ -718,6 +739,7 @@ var _ = Describe("creating API with different options", func() {
 
 	It("handles bogus operations", func() {
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.IgnoreMissingToken(),
 			),
@@ -743,6 +765,7 @@ var _ = Describe("creating API with different options", func() {
 		)
 
 		api, err := NewAPI(
+			WithLogger(logger),
 			WithClientOptions(
 				client.BaseURL(server.URL()),
 				client.IgnoreMissingToken(),

--- a/pkg/api/internal/options.go
+++ b/pkg/api/internal/options.go
@@ -33,3 +33,12 @@ type ObjectChannelOption struct {
 func (aoc ObjectChannelOption) ApplyToList(o *types.ListOptions) {
 	o.ObjectChannel = aoc.Channel
 }
+
+// FullObjectsOption configures if the List operation shall make a Get operation for each object before
+// returning it to the caller.
+type FullObjectsOption bool
+
+// ApplyToList applies the FullObjectsOption option to all the ListOptions.
+func (foo FullObjectsOption) ApplyToList(o *types.ListOptions) {
+	o.FullObjects = bool(foo)
+}

--- a/pkg/api/mockserver_test.go
+++ b/pkg/api/mockserver_test.go
@@ -122,11 +122,14 @@ func newMockServer() *ghttp.Server {
 			}
 		}
 
-		ret := make([]backend.Backend, 0, len(backends))
+		ret := make([]map[string]string, 0, len(backends))
 
 		for _, b := range backends {
 			if lb_filter == nil || b.LoadBalancer.Identifier == *lb_filter {
-				ret = append(ret, b)
+				ret = append(ret, map[string]string{
+					"name":       b.Name,
+					"identifier": b.Identifier,
+				})
 			}
 		}
 
@@ -135,7 +138,7 @@ func newMockServer() *ghttp.Server {
 			idxEnd := idxStart + limit
 
 			if idxStart >= len(ret) {
-				ret = make([]backend.Backend, 0)
+				ret = []map[string]string{}
 			} else {
 				if idxEnd > len(ret) {
 					idxEnd = len(ret)

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -20,3 +20,12 @@ func Paged(page, limit uint, info *types.PageInfo) ListOption {
 		Info:  info,
 	}
 }
+
+// FullObjects can be set to make a Get for every object before it is returned to the caller of List(). This
+// is necessary since most API endpoints for listing objects only return a subset of their data.
+//
+// Beware: this makes one API call to retrieve the objects (ok, one call per page of objects) and an additional
+// call per object. Because of this being very slow, it is an optional feature and should only be used with care.
+func FullObjects(fullObjects bool) ListOption {
+	return internal.FullObjectsOption(fullObjects)
+}

--- a/pkg/api/pagination.go
+++ b/pkg/api/pagination.go
@@ -86,7 +86,7 @@ func (p *pageIter) Next(objects interface{}) bool {
 		elementType := val.Elem().Type().Elem()
 		ptrToElementType := reflect.PtrTo(elementType)
 
-		isObjects = elementType.Implements(objectType) || ptrToElementType.Implements(objectType)
+		isObjects = ptrToElementType.Implements(objectType)
 		isRawMessages = elementType == reflect.TypeOf((*json.RawMessage)(nil)).Elem()
 	}
 
@@ -96,7 +96,7 @@ func (p *pageIter) Next(objects interface{}) bool {
 	// json.RawMessage is allowed for retrieving objects via channel, where the page is decoded into an array of
 	// json.RawMessage and every entry of that is decoded into the target object as soon as it is needed.
 	if !isPointer || !isArrayOrSlice || (!isObjects && !isRawMessages) {
-		p.err = fmt.Errorf("%w: the argument given to PageInfo.Next() must be a pointer to []T where T or *T implements types.Object or T is json.RawMessage; expected *[]T, you gave %v", ErrTypeNotSupported, wrongType)
+		p.err = fmt.Errorf("%w: the argument given to PageInfo.Next() must be a pointer to []T where *T implements types.Object or T is json.RawMessage; expected *[]T, you gave %v", ErrTypeNotSupported, wrongType)
 		return false
 	}
 

--- a/pkg/api/pagination_test.go
+++ b/pkg/api/pagination_test.go
@@ -68,7 +68,7 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 			EntriesPerPage: 2,
 		}
 
-		pi, piCreateError = newPageIter(context.TODO(), responseBody, opts, fetcher, false)
+		pi, piCreateError = newPageIter(context.TODO(), nil, responseBody, opts, fetcher, false)
 	})
 
 	AssertCommonBehavior := func() {

--- a/pkg/api/types/operation.go
+++ b/pkg/api/types/operation.go
@@ -30,12 +30,15 @@ type GetOptions struct {
 // ListOptions contains options valid for List operations.
 type ListOptions struct {
 	commonOptions
+
 	ObjectChannel *ObjectChannel
 
 	Paged          bool
 	Page           uint
 	EntriesPerPage uint
 	PageInfo       *PageInfo
+
+	FullObjects bool
 }
 
 // CreateOptions contains options valid for Create operations.


### PR DESCRIPTION
### Description

I think title says enough already ^^'

This also fixes some other small things, neatly in their own commits.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* NONE (updating unreleased code)
```

### References
* generic client introduced in #56
* SYSENG-684

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
