### PR TITLE
Re-enable vsphere integration tests

### DIFF
--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -73,7 +73,7 @@ func vsphereTestInit() {
 	templateID = selected[0].ID
 }
 
-var _ = PDescribe("vsphere API endpoint tests", func() {
+var _ = Describe("vsphere API endpoint tests", func() {
 
 	var cli client.Client
 


### PR DESCRIPTION
### Description

VSphere integration tests were disabled in #76. They seem to work again, let's run them again.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References
* disabled in #76 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
