### PR TITLE
✨💥: fundamentally change List via channel

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -490,8 +490,8 @@ var _ = Describe("creating API with different options", func() {
 		o := api_test_object{"identifier"}
 
 		var pi types.PageInfo
-		oc := make(types.ObjectChannel)
-		err = api.List(context.TODO(), &o, Paged(1, 2, &pi), AsObjectChannel(&oc))
+		oc := NewObjectChannel()
+		err = api.List(context.TODO(), &o, Paged(1, 2, &pi), ObjectChannel(oc))
 		Expect(err).To(MatchError(ErrCannotListChannelAndPaged))
 	})
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -37,6 +37,9 @@ var (
 
 	// ErrContextRequired is returned when a nil context was passed as argument.
 	ErrContextRequired = errors.New("no context given")
+
+	// ErrObjectChannelNotReady is returned when trying to use an object channel that was not prepared by a List operation yet.
+	ErrObjectChannelNotReady = errors.New("object channel not ready to be used")
 )
 
 // EngineError is the base type for all errors returned by the engine.

--- a/pkg/api/internal/options.go
+++ b/pkg/api/internal/options.go
@@ -24,12 +24,12 @@ func (p PagedOption) ApplyToList(o *types.ListOptions) {
 	o.PageInfo = p.Info
 }
 
-// AsObjectChannelOption configures the List operation to return the objects via the given channel.
-type AsObjectChannelOption struct {
-	Channel *types.ObjectChannel
+// ObjectChannelOption configures the List operation to return the objects via the given channel.
+type ObjectChannelOption struct {
+	Channel types.ObjectChannelCloser
 }
 
-// ApplyToList applies the AsObjectChannel option to all the ListOptions.
-func (aoc AsObjectChannelOption) ApplyToList(o *types.ListOptions) {
-	o.ObjectChannel = aoc.Channel
+// ApplyToList applies the ObjectChannelOption to all the ListOptions.
+func (oc ObjectChannelOption) ApplyToList(o *types.ListOptions) {
+	o.Channel = oc.Channel
 }

--- a/pkg/api/object_channel.go
+++ b/pkg/api/object_channel.go
@@ -42,46 +42,7 @@ func (oc *objectChannel) Channel() (types.ObjectChannel, error) {
 	}
 
 	pageRetrieveWaiter := make(chan bool)
-
-	go func() {
-		var pageData []json.RawMessage
-
-	cancelChannel:
-		for oc.pageIterator.Next(&pageData) {
-			for _, o := range pageData {
-				select {
-				case <-oc.abort:
-					oc.log.Info("User requested aborting the channel")
-					break cancelChannel
-				case <-pageRetrieveWaiter:
-					oc.log.Info("Object retrieved by user")
-				}
-
-				oc.log.Info("Pushing retriever on channel")
-
-				// since we are in a goroutine, we might already be in the next iteration of this loop
-				// at the time the receiving end of this channel calls the closure. Having a loop-body
-				// scoped variables makes the data for the closure perfectly identified.
-				closureData := o
-				oc.objects <- func(out types.Object) error {
-					err := decodeResponse(oc.ctx, "application/json", bytes.NewBuffer(closureData), out)
-					if err != nil {
-						return err
-					}
-
-					pageRetrieveWaiter <- true
-					return nil
-				}
-			}
-
-			oc.log.Info("Retrieving next page")
-		}
-
-		// we have to wait for last retriever used before closing the channel
-		<-pageRetrieveWaiter
-		close(oc.objects)
-	}()
-
+	go oc.run(pageRetrieveWaiter)
 	pageRetrieveWaiter <- true
 
 	return types.ObjectChannel(oc.objects), nil
@@ -119,4 +80,43 @@ func (oc *objectChannel) prepare(ctx context.Context, api API, opts *types.ListO
 	opts.PageInfo = &oc.pageIterator
 
 	return nil
+}
+
+func (oc *objectChannel) run(pageRetrieveWaiter chan bool) {
+	var pageData []json.RawMessage
+
+cancelChannel:
+	for oc.pageIterator.Next(&pageData) {
+		for _, o := range pageData {
+			select {
+			case <-oc.abort:
+				oc.log.Info("User requested aborting the channel")
+				break cancelChannel
+			case <-pageRetrieveWaiter:
+				oc.log.Info("Object retrieved by user")
+			}
+
+			oc.log.Info("Pushing retriever on channel")
+
+			// since we are in a goroutine, we might already be in the next iteration of this loop
+			// at the time the receiving end of this channel calls the closure. Having a loop-body
+			// scoped variables makes the data for the closure perfectly identified.
+			closureData := o
+			oc.objects <- func(out types.Object) error {
+				err := decodeResponse(oc.ctx, "application/json", bytes.NewBuffer(closureData), out)
+				if err != nil {
+					return err
+				}
+
+				pageRetrieveWaiter <- true
+				return nil
+			}
+		}
+
+		oc.log.Info("Retrieving next page")
+	}
+
+	// we have to wait for last retriever used before closing the channel
+	<-pageRetrieveWaiter
+	close(oc.objects)
 }

--- a/pkg/api/object_channel.go
+++ b/pkg/api/object_channel.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+	"github.com/go-logr/logr"
+)
+
+const (
+	// ListChannelDefaultPageSize specifies the default page size for List operations returning the data via channel.
+	ListChannelDefaultPageSize = 10
+)
+
+type objectChannel struct {
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
+	api API
+	log logr.Logger
+
+	objects      chan types.ObjectRetriever
+	abort        chan bool
+	pageIterator types.PageInfo
+}
+
+// NewObjectChannel creates a new object implementing types.ObjectChannelCloser which can be used after passed to API.List()
+// with the ObjectChannel option.
+func NewObjectChannel() types.ObjectChannelCloser {
+	return &objectChannel{
+		objects: make(chan types.ObjectRetriever),
+		abort:   make(chan bool),
+	}
+}
+
+// Channel starts the object listing logic and returns the channel objects can be retrieved from.
+func (oc *objectChannel) Channel() (types.ObjectChannel, error) {
+	if oc.pageIterator == nil {
+		return nil, ErrObjectChannelNotReady
+	}
+
+	pageRetrieveWaiter := make(chan bool)
+
+	go func() {
+		var pageData []json.RawMessage
+
+	cancelChannel:
+		for oc.pageIterator.Next(&pageData) {
+			for _, o := range pageData {
+				select {
+				case <-oc.abort:
+					oc.log.Info("User requested aborting the channel")
+					break cancelChannel
+				case <-pageRetrieveWaiter:
+					oc.log.Info("Object retrieved by user")
+				}
+
+				oc.log.Info("Pushing retriever on channel")
+
+				// since we are in a goroutine, we might already be in the next iteration of this loop
+				// at the time the receiving end of this channel calls the closure. Having a loop-body
+				// scoped variables makes the data for the closure perfectly identified.
+				closureData := o
+				oc.objects <- func(out types.Object) error {
+					err := decodeResponse(oc.ctx, "application/json", bytes.NewBuffer(closureData), out)
+					if err != nil {
+						return err
+					}
+
+					pageRetrieveWaiter <- true
+					return nil
+				}
+			}
+
+			oc.log.Info("Retrieving next page")
+		}
+
+		// we have to wait for last retriever used before closing the channel
+		<-pageRetrieveWaiter
+		close(oc.objects)
+	}()
+
+	pageRetrieveWaiter <- true
+
+	return types.ObjectChannel(oc.objects), nil
+}
+
+// Close signals to abort listing objects and cancels any currently ongoing API requests.
+func (oc *objectChannel) Close() error {
+	if oc.pageIterator == nil {
+		return ErrObjectChannelNotReady
+	}
+
+	oc.abort <- true
+	oc.ctxCancel()
+	return nil
+}
+
+func (oc *objectChannel) prepare(ctx context.Context, api API, opts *types.ListOptions) error {
+	// configure the List operation to be paged with default settings if no other settings are configured
+	// by the user already
+	if !opts.Paged {
+		opts.Paged = true
+		opts.Page = 1
+		opts.EntriesPerPage = ListChannelDefaultPageSize
+	} else if opts.PageInfo != nil {
+		// user tried to retrieve a page iterator and object channel - since we only create a single page
+		// iterator used by the channel, returning this to the user wouldn't have the intended effects, so
+		// we deny that.
+		return ErrCannotListChannelAndPaged
+	}
+
+	oc.ctx, oc.ctxCancel = context.WithCancel(ctx)
+	oc.api = api
+	oc.log = logr.FromContextOrDiscard(ctx).WithName("ObjectChannel").V(2)
+
+	opts.PageInfo = &oc.pageIterator
+
+	return nil
+}

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -5,9 +5,10 @@ import (
 	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 )
 
-// AsObjectChannel configures the List operation to return the objects via the given channel.
-func AsObjectChannel(channel *types.ObjectChannel) ListOption {
-	return internal.AsObjectChannelOption{Channel: channel}
+// ObjectChannel returns a ListOption to configure the List operation to return the objects via the ObjectChannel
+// given as argument.
+func ObjectChannel(ch types.ObjectChannelCloser) ListOption {
+	return internal.ObjectChannelOption{Channel: ch}
 }
 
 // Paged is an option valid for List operations to retrieve objects in a paged fashion (instead of all at once).

--- a/pkg/api/types/channel.go
+++ b/pkg/api/types/channel.go
@@ -1,0 +1,16 @@
+package types
+
+// ObjectRetriever retrieves an object and decodes it to the correct go type.
+type ObjectRetriever func(Object) error
+
+// ObjectChannel streams objects.
+type ObjectChannel <-chan ObjectRetriever
+
+// ObjectChannelCloser is used to List objects via a channel that can be closed by the retriever, canceling
+// the list operation.
+// The user is required to call Close() when not reading the channel until it finishes, it will leak goroutines
+// otherwise.
+type ObjectChannelCloser interface {
+	Channel() (ObjectChannel, error)
+	Close() error
+}

--- a/pkg/api/types/operation.go
+++ b/pkg/api/types/operation.go
@@ -30,7 +30,7 @@ type GetOptions struct {
 // ListOptions contains options valid for List operations.
 type ListOptions struct {
 	commonOptions
-	ObjectChannel *ObjectChannel
+	Channel ObjectChannelCloser
 
 	Paged          bool
 	Page           uint

--- a/pkg/api/types/types.go
+++ b/pkg/api/types/types.go
@@ -1,9 +1,3 @@
 // Package types contains everything needed by APIs implementing the interfaces to be compatible with the
 // generic API client.
 package types
-
-// ObjectReturner retrieves an object, parsing it to the correct go type.
-type ObjectReturner func(Object) error
-
-// ObjectChannel streams objects.
-type ObjectChannel chan ObjectReturner


### PR DESCRIPTION
### Description

Previous to this commit, we let users create a channel variable and pass
a pointer to this to the AsObjectChannel option, which initialized it
and made the API client spawn a goroutine to fill it.

We now let the user create a "ObjectChannelCloser" via NewObjectChannel
and pass that to the (renamed) ObjectChannel option. Via this new
ObjectChannelCloser, the user can retrieve the go channel to stream
objects as previous, but also cancel the listing - which was not
possible before and leaked goroutines whenever the channel was not read
until it finished.

<!--- Please leave a helpful description of the pull request here. --->

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE (changing unreleased feature)
```

### References
* generic client introduced in #56
* found the missing feature while writing another test for #79 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
