### PR TITLE
Allow cancelling List operations via channel

### DIFF
--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -161,7 +161,7 @@ func ExampleAPI_listChannel() {
 	// see example on NewAPI how to implement this function
 	apiClient := newExampleAPI()
 
-	channel := make(types.ObjectChannel)
+	var channel types.ObjectChannel
 
 	// list all backends using a channel and have the library handle the paging.
 	// Oh and we filter by LoadBalancer, because we can and the example has to be somewhere.

--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -169,7 +169,7 @@ func ExampleAPI_listChannel() {
 	// Beware: listing endpoints usually do not return all data for an object, sometimes
 	// only the identifier is filled. This varies by specific API.
 	b := backend.Backend{LoadBalancer: loadbalancer.LoadBalancerInfo{Identifier: "bogus identifier 2"}}
-	if err := apiClient.List(context.TODO(), &b, AsObjectChannel(&channel)); err != nil {
+	if err := apiClient.List(context.TODO(), &b, ObjectChannel(&channel)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)
 	} else {
 		for res := range channel {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -577,6 +577,109 @@ var _ = Describe("creating API with different options", func() {
 		Expect(server.ReceivedRequests()).To(HaveLen(1))
 	})
 
+	It("can list objects with channel", func() {
+		server.AppendHandlers(
+			ghttp.RespondWith(200, `[{"value":"foo"},{"value":"bar"}]`, http.Header{"Content-Type": []string{"application/json"}}),
+		)
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"no_pagination"}
+
+		var ch types.ObjectChannel
+		err = api.List(context.TODO(), &o, ObjectChannel(&ch))
+		Expect(err).NotTo(HaveOccurred())
+
+		i := 0
+		for retriever := range ch {
+			err = retriever(&o)
+			Expect(err).NotTo(HaveOccurred())
+
+			switch i {
+			case 0:
+				Expect(o.Val).To(Equal("foo"))
+			case 1:
+				Expect(o.Val).To(Equal("bar"))
+			default:
+				Fail("unexpected number of objects")
+			}
+
+			i++
+		}
+
+		Expect(i).To(Equal(2))
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+	})
+
+	It("listing objects with channel handles decode errors", func() {
+		server.AppendHandlers(
+			ghttp.RespondWith(200, `[{"value":"foo"},{"value":"bar"}]`, http.Header{"Content-Type": []string{"application/json"}}),
+		)
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"failing_decode_response"}
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		var ch types.ObjectChannel
+		err = api.List(ctx, &o, ObjectChannel(&ch))
+		Expect(err).NotTo(HaveOccurred())
+
+		retriever := <-ch
+		cancel()
+
+		err = retriever(&o)
+		Expect(err).To(MatchError(api_test_error))
+
+		Eventually(ch).Should(BeClosed())
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+	})
+
+	It("can abort listing objects with channel", func() {
+		server.AppendHandlers(
+			ghttp.RespondWith(200, `[{"value":"foo"},{"value":"bar"},{"value":"baz"},{"value":"bla"}]`, http.Header{"Content-Type": []string{"application/json"}}),
+		)
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := api_test_object{"no_pagination"}
+
+		ctx, cancel := context.WithCancel(context.TODO())
+		var ch types.ObjectChannel
+		err = api.List(ctx, &o, ObjectChannel(&ch))
+		Expect(err).NotTo(HaveOccurred())
+
+		// to prevent having another retriever pushed to the channel we have to
+		// cancel before running the retriever
+		retriever := <-ch
+		cancel()
+
+		err = retriever(&o)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(o.Val).To(Equal("foo"))
+
+		Eventually(ch).Should(BeClosed())
+		Expect(server.ReceivedRequests()).To(HaveLen(1))
+	})
+
 	It("handles http.Client.Do() returning an error", func() {
 		hc := http.Client{
 			Transport: api_test_error_roundtripper(false),

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -491,7 +491,7 @@ var _ = Describe("creating API with different options", func() {
 
 		var pi types.PageInfo
 		oc := make(types.ObjectChannel)
-		err = api.List(context.TODO(), &o, Paged(1, 2, &pi), AsObjectChannel(&oc))
+		err = api.List(context.TODO(), &o, Paged(1, 2, &pi), ObjectChannel(&oc))
 		Expect(err).To(MatchError(ErrCannotListChannelAndPaged))
 	})
 

--- a/pkg/api/internal/options.go
+++ b/pkg/api/internal/options.go
@@ -24,12 +24,12 @@ func (p PagedOption) ApplyToList(o *types.ListOptions) {
 	o.PageInfo = p.Info
 }
 
-// AsObjectChannelOption configures the List operation to return the objects via the given channel.
-type AsObjectChannelOption struct {
+// ObjectChannelOption configures the List operation to return the objects via the given channel.
+type ObjectChannelOption struct {
 	Channel *types.ObjectChannel
 }
 
 // ApplyToList applies the AsObjectChannel option to all the ListOptions.
-func (aoc AsObjectChannelOption) ApplyToList(o *types.ListOptions) {
+func (aoc ObjectChannelOption) ApplyToList(o *types.ListOptions) {
 	o.ObjectChannel = aoc.Channel
 }

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -5,7 +5,9 @@ import (
 	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 )
 
-// ObjectChannel configures the List operation to return the objects via the given channel.
+// ObjectChannel configures the List operation to return the objects via the given channel. When listing via
+// channel you either have to read until the channel is closed or pass a context you cancel explicitly - failing
+// to do that will result in leaked goroutines.
 func ObjectChannel(channel *types.ObjectChannel) ListOption {
 	return internal.ObjectChannelOption{Channel: channel}
 }

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -5,9 +5,9 @@ import (
 	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 )
 
-// AsObjectChannel configures the List operation to return the objects via the given channel.
-func AsObjectChannel(channel *types.ObjectChannel) ListOption {
-	return internal.AsObjectChannelOption{Channel: channel}
+// ObjectChannel configures the List operation to return the objects via the given channel.
+func ObjectChannel(channel *types.ObjectChannel) ListOption {
+	return internal.ObjectChannelOption{Channel: channel}
 }
 
 // Paged is an option valid for List operations to retrieve objects in a paged fashion (instead of all at once).

--- a/pkg/api/types/types.go
+++ b/pkg/api/types/types.go
@@ -2,8 +2,8 @@
 // generic API client.
 package types
 
-// ObjectReturner retrieves an object, parsing it to the correct go type.
-type ObjectReturner func(Object) error
+// ObjectRetriever retrieves an object, parsing it to the correct go type.
+type ObjectRetriever func(Object) error
 
 // ObjectChannel streams objects.
-type ObjectChannel chan ObjectReturner
+type ObjectChannel <-chan ObjectRetriever


### PR DESCRIPTION
### Description

List operations with results via channel had to be read until everything was received. This PR implements the ability to cancel the context, cancelling the List operation.

Also renames the `AsObjectChannel` option to `ObjectChannel`, looks better imho.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* NONE (addition to unreleased feature)
```

### References
* generic client introduced in #56 
* Closes #81 (this is a better way to do that)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
