### PR TITLE
Move generic client APIs into pkg/apis/

### DIFF
--- a/pkg/api/api_examples_test.go
+++ b/pkg/api/api_examples_test.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	lbaasv1 "github.com/anexia-it/go-anxcloud/pkg/apis/lbaas/v1"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/backend"
-	lbaasCommon "github.com/anexia-it/go-anxcloud/pkg/lbaas/common"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/loadbalancer"
 
 	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 )
@@ -23,7 +21,7 @@ func ExampleNewAPI() {
 		log.Fatalf("Error creating api instance: %v\n", err)
 	} else {
 		// do something with api
-		lb := loadbalancer.Loadbalancer{Identifier: "bogus identifier"}
+		lb := lbaasv1.LoadBalancer{Identifier: "bogus identifier"}
 		if err := api.Get(context.TODO(), &lb); IgnoreNotFound(err) != nil {
 			fmt.Printf("Error retrieving loadbalancer with identifier '%v'\n", lb.Identifier)
 		}
@@ -39,14 +37,14 @@ func Example_usage() {
 	apiClient := newExampleAPI()
 
 	// retrieve and create backend, handling errors along the way.
-	backend := backend.Backend{Identifier: "bogus identifier 1"}
+	backend := lbaasv1.Backend{Identifier: "bogus identifier 1"}
 	if err := apiClient.Get(context.TODO(), &backend); IgnoreNotFound(err) != nil {
 		fmt.Printf("Fatal error while retrieving backend: %v\n", err)
 	} else if err != nil {
 		fmt.Printf("Backend not yet existing, creating ...\n")
 
 		backend.Name = "backend-01"
-		backend.Mode = lbaasCommon.HTTP
+		backend.Mode = lbaasv1.HTTP
 		// [...]
 
 		if err := apiClient.Create(context.TODO(), &backend); err != nil {
@@ -70,9 +68,9 @@ func ExampleAPI_create() {
 	// see example on NewAPI how to implement this function
 	apiClient := newExampleAPI()
 
-	backend := backend.Backend{
+	backend := lbaasv1.Backend{
 		Name: "backend-01",
-		Mode: lbaasCommon.HTTP,
+		Mode: lbaasv1.HTTP,
 		// [...]
 	}
 
@@ -89,7 +87,7 @@ func ExampleAPI_destroy() {
 	// see example on NewAPI how to implement this function
 	apiClient := newExampleAPI()
 
-	backend := backend.Backend{Identifier: "bogus identifier 1"}
+	backend := lbaasv1.Backend{Identifier: "bogus identifier 1"}
 	if err := apiClient.Destroy(context.TODO(), &backend); err != nil {
 		fmt.Printf("Error destroying backend: %v\n", err)
 	} else {
@@ -103,7 +101,7 @@ func ExampleAPI_get() {
 	// see example on NewAPI how to implement this function
 	apiClient := newExampleAPI()
 
-	backend := backend.Backend{Identifier: "bogus identifier 1"}
+	backend := lbaasv1.Backend{Identifier: "bogus identifier 1"}
 	if err := apiClient.Get(context.TODO(), &backend); err != nil {
 		fmt.Printf("Error retrieving backend: %v\n", err)
 	} else {
@@ -121,12 +119,12 @@ func ExampleAPI_listPaged() {
 
 	// Beware: listing endpoints usually do not return all data for an object, sometimes
 	// only the identifier is filled. This varies by specific API.
-	b := backend.Backend{}
+	b := lbaasv1.Backend{}
 	var pageIter types.PageInfo
 	if err := apiClient.List(context.TODO(), &b, Paged(1, 2, &pageIter)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)
 	} else {
-		var backends []backend.Backend
+		var backends []lbaasv1.Backend
 		for pageIter.Next(&backends) {
 			fmt.Printf("Listing entries on page %v\n", pageIter.CurrentPage())
 
@@ -168,7 +166,7 @@ func ExampleAPI_listChannel() {
 
 	// Beware: listing endpoints usually do not return all data for an object, sometimes
 	// only the identifier is filled. This varies by specific API.
-	b := backend.Backend{LoadBalancer: loadbalancer.LoadBalancerInfo{Identifier: "bogus identifier 2"}}
+	b := lbaasv1.Backend{LoadBalancer: lbaasv1.LoadBalancer{Identifier: "bogus identifier 2"}}
 	if err := apiClient.List(context.TODO(), &b, ObjectChannel(&channel)); err != nil {
 		fmt.Printf("Error listing backends: %v\n", err)
 	} else {
@@ -192,10 +190,10 @@ func ExampleAPI_update() {
 	// see example on NewAPI how to implement this function
 	apiClient := newExampleAPI()
 
-	b := backend.Backend{
+	b := lbaasv1.Backend{
 		Identifier: "bogus identifier 1",
 		Name:       "Updated backend",
-		Mode:       lbaasCommon.HTTP,
+		Mode:       lbaasv1.HTTP,
 		// [...]
 	}
 
@@ -204,7 +202,7 @@ func ExampleAPI_update() {
 	} else {
 		fmt.Printf("Successfully updated backend\n")
 
-		retrieved := backend.Backend{Identifier: "bogus identifier 1"}
+		retrieved := lbaasv1.Backend{Identifier: "bogus identifier 1"}
 		if err := apiClient.Get(context.TODO(), &retrieved); err != nil {
 			fmt.Printf("Error verifying updated backend: %v\n", err)
 		} else {

--- a/pkg/apis/core/v1/resource_genclient.go
+++ b/pkg/apis/core/v1/resource_genclient.go
@@ -1,0 +1,42 @@
+package v1
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api"
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+	"github.com/go-logr/logr"
+)
+
+func (i Info) EndpointURL(ctx context.Context) (*url.URL, error) {
+	u, err := url.ParseRequestURI("/api/core/v1/resource.json")
+	if err != nil {
+		return nil, err
+	}
+
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	switch op {
+	// OperationCreate is not supported because the API does not exist in the engine.
+	// OperationDestroy and OperationUpdate is not yet implemented
+	case types.OperationCreate, types.OperationDestroy, types.OperationUpdate:
+		return nil, api.ErrOperationNotSupported
+	}
+
+	if op == types.OperationList {
+		query := u.Query()
+
+		if len(i.Tags) > 1 {
+			logr.FromContextOrDiscard(ctx).Info("Listing with multiple tags isn't supported. Only first one used")
+		}
+
+		if len(i.Tags) > 0 {
+			query.Add("tag_name", i.Tags[0])
+		}
+		u.RawQuery = query.Encode()
+	}
+	return u, err
+}

--- a/pkg/apis/core/v1/resource_types.go
+++ b/pkg/apis/core/v1/resource_types.go
@@ -1,0 +1,17 @@
+package v1
+
+// Type is part of info.
+type Type struct {
+	Identifier string `json:"identifier"`
+	Name       string `json:"name"`
+}
+
+// anxcloud:object
+
+// Info contains all information about a resource.
+type Info struct {
+	Identifier string   `json:"identifier" anxcloud:"identifier"`
+	Name       string   `json:"name"`
+	Type       Type     `json:"resource_type"`
+	Tags       []string `json:"tags"`
+}

--- a/pkg/apis/core/v1/spec_runner_test.go
+++ b/pkg/apis/core/v1/spec_runner_test.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCore(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "test suite for core API definition")
+}

--- a/pkg/apis/core/v1/xxgenerated_object_test.go
+++ b/pkg/apis/core/v1/xxgenerated_object_test.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	. "github.com/anexia-it/go-anxcloud/pkg/utils/test/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+var _ = Describe("Object Info", func() {
+	It("implements the interface types.Object", func() {
+		var i types.Object
+		o := Info{}
+		Expect(&o).To(ImplementInterface(&i))
+	})
+})

--- a/pkg/apis/lbaas/v1/backend_genclient.go
+++ b/pkg/apis/lbaas/v1/backend_genclient.go
@@ -1,0 +1,72 @@
+package v1
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+// EndpointURL returns the URL where to retrieve objects of type Backend and the identifier of the given Backend.
+// It implements the api.Object interface on *Backend, making it usable with the generic API client.
+func (b *Backend) EndpointURL(ctx context.Context) (*url.URL, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.Parse("/api/LBaaS/v1/backend.json")
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationList {
+		filters := make(url.Values)
+
+		if b.LoadBalancer.Identifier != "" {
+			filters.Add("load_balancer", b.LoadBalancer.Identifier)
+		}
+
+		if b.Mode != "" {
+			filters.Add("mode", string(b.Mode))
+		}
+
+		query := u.Query()
+		query.Add("filters", filters.Encode())
+		u.RawQuery = query.Encode()
+	}
+
+	return u, err
+}
+
+// FilterAPIRequestBody generates the request body for creating a new Backend, which differs from the Backend object.
+func (b *Backend) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationCreate {
+		return struct {
+			Name         string `json:"name"`
+			LoadBalancer string `json:"load_balancer"`
+			Mode         Mode   `json:"mode"`
+			State        State  `json:"state"`
+		}{
+			Name:         b.Name,
+			Mode:         b.Mode,
+			LoadBalancer: b.LoadBalancer.Identifier,
+			State:        NewlyCreated,
+		}, nil
+	} else if op == types.OperationUpdate {
+		return struct {
+			Backend
+			LoadBalancer string `json:"load_balancer"`
+		}{
+			Backend:      *b,
+			LoadBalancer: b.LoadBalancer.Identifier,
+		}, nil
+	}
+
+	return b, nil
+}

--- a/pkg/apis/lbaas/v1/backend_types.go
+++ b/pkg/apis/lbaas/v1/backend_types.go
@@ -1,0 +1,17 @@
+package v1
+
+// anxcloud:object:hooks=RequestBodyHook
+
+// The Backend resource configures settings common for all specific backend Server resources linked to it.
+type Backend struct {
+	CustomerIdentifier string `json:"customer_identifier"`
+	ResellerIdentifier string `json:"reseller_identifier"`
+	Identifier         string `json:"identifier" anxcloud:"identifier"`
+	Name               string `json:"name"`
+	HealthCheck        string `json:"health_check"`
+	Mode               Mode   `json:"mode"`
+	ServerTimeout      int    `json:"server_timeout"`
+
+	// Only the name and identifier fields are used and returned.
+	LoadBalancer LoadBalancer `json:"load_balancer"`
+}

--- a/pkg/apis/lbaas/v1/frontend_genclient.go
+++ b/pkg/apis/lbaas/v1/frontend_genclient.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+// EndpointURL returns the URL where to retrieve objects of type Frontend and the identifier of the given Frontend.
+// It implements the api.Object interface on *Frontend, making it usable with the generic API client.
+func (f *Frontend) EndpointURL(ctx context.Context) (*url.URL, error) {
+	url, err := url.ParseRequestURI("/api/LBaaS/v1/frontend.json")
+	return url, err
+}
+
+// FilterAPIRequestBody generates the request body for creating a new Frontend, which differs from the Frontend object.
+func (f *Frontend) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationCreate {
+		return struct {
+			Name           string `json:"name"`
+			LoadBalancer   string `json:"load_balancer"`
+			DefaultBackend string `json:"default_backend"`
+			State          State  `json:"state"`
+		}{
+			Name:           f.Name,
+			LoadBalancer:   f.LoadBalancer.Identifier,
+			DefaultBackend: f.DefaultBackend.Identifier,
+			State:          NewlyCreated,
+		}, nil
+	} else if op == types.OperationUpdate {
+		return struct {
+			Frontend
+			LoadBalancer   string `json:"load_balancer"`
+			DefaultBackend string `json:"default_backend"`
+		}{
+			Frontend:       *f,
+			LoadBalancer:   f.LoadBalancer.Identifier,
+			DefaultBackend: f.DefaultBackend.Identifier,
+		}, nil
+	}
+
+	return f, nil
+}

--- a/pkg/apis/lbaas/v1/frontend_types.go
+++ b/pkg/apis/lbaas/v1/frontend_types.go
@@ -1,0 +1,19 @@
+package v1
+
+// anxcloud:object:hooks=RequestBodyHook
+
+// Frontend represents a LBaaS Frontend.
+type Frontend struct {
+	CustomerIdentifier string `json:"customer_identifier"`
+	ResellerIdentifier string `json:"reseller_identifier"`
+	Identifier         string `json:"identifier"`
+	Name               string `json:"name"`
+	Mode               Mode   `json:"mode"`
+	ClientTimeout      string `json:"client_timeout"`
+
+	// Only the name and identifier fields are used and returned.
+	LoadBalancer *LoadBalancer `json:"load_balancer,omitempty"`
+
+	// Only the name and identifier fields are used and returned.
+	DefaultBackend *Backend `json:"default_backend,omitempty"`
+}

--- a/pkg/apis/lbaas/v1/loadbalancer_genclient.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_genclient.go
@@ -1,0 +1,33 @@
+package v1
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+// EndpointURL returns the URL where to retrieve objects of type LoadBalancer and the identifier of the given Loadbalancer.
+// It implements the api.Object interface on *LoadBalancer, making it usable with the generic API client.
+func (lb *LoadBalancer) EndpointURL(ctx context.Context) (*url.URL, error) {
+	url, err := url.ParseRequestURI("/api/LBaaS/v1/loadbalancer.json")
+	return url, err
+}
+
+// FilterAPIRequestBody generates the request body for creating a new LoadBalancer, which differs from the LoadBalancer object.
+func (lb *LoadBalancer) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationCreate {
+		return map[string]string{
+			"name":       lb.Name,
+			"ip_address": lb.IpAddress,
+			"state":      "2",
+		}, nil
+	}
+
+	return lb, nil
+}

--- a/pkg/apis/lbaas/v1/loadbalancer_types.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_types.go
@@ -1,0 +1,19 @@
+package v1
+
+// RuleInfo holds the name and identifier of a rule.
+type RuleInfo struct {
+	Identifier string `json:"identifier" anxcloud:"identifier"`
+	Name       string `json:"name"`
+}
+
+// anxcloud:object:hooks=RequestBodyHook
+
+// LoadBalancer holds the information of a load balancer instance.
+type LoadBalancer struct {
+	CustomerIdentifier string     `json:"customer_identifier"`
+	ResellerIdentifier string     `json:"reseller_identifier"`
+	Identifier         string     `json:"identifier" anxcloud:"identifier"`
+	Name               string     `json:"name"`
+	IpAddress          string     `json:"ip_address"`
+	AutomationRules    []RuleInfo `json:"automation_rules"`
+}

--- a/pkg/apis/lbaas/v1/spec_runner_test.go
+++ b/pkg/apis/lbaas/v1/spec_runner_test.go
@@ -1,4 +1,4 @@
-package loadbalancer
+package v1
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestLoadbalancer(t *testing.T) {
+func TestLBaaS(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "test suite for Loadbalancer")
+	RunSpecs(t, "test suite for LBaaS API definition")
 }

--- a/pkg/apis/lbaas/v1/types.go
+++ b/pkg/apis/lbaas/v1/types.go
@@ -1,0 +1,18 @@
+package v1
+
+type Mode string
+
+const (
+	TCP  = Mode("tcp")
+	HTTP = Mode("http")
+)
+
+type State string
+
+const (
+	Updating        = State("0")
+	Updated         = State("1")
+	DeploymentError = State("2")
+	Deployed        = State("3")
+	NewlyCreated    = State("4")
+)

--- a/pkg/apis/lbaas/v1/xxgenerated_object_test.go
+++ b/pkg/apis/lbaas/v1/xxgenerated_object_test.go
@@ -1,0 +1,48 @@
+package v1
+
+import (
+	. "github.com/anexia-it/go-anxcloud/pkg/utils/test/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/anexia-it/go-anxcloud/pkg/api/types"
+)
+
+var _ = Describe("Object Backend", func() {
+	It("implements the interface types.Object", func() {
+		var i types.Object
+		o := Backend{}
+		Expect(&o).To(ImplementInterface(&i))
+	})
+	It("implements the interface types.RequestBodyHook", func() {
+		var i types.RequestBodyHook
+		o := Backend{}
+		Expect(&o).To(ImplementInterface(&i))
+	})
+})
+
+var _ = Describe("Object Frontend", func() {
+	It("implements the interface types.Object", func() {
+		var i types.Object
+		o := Frontend{}
+		Expect(&o).To(ImplementInterface(&i))
+	})
+	It("implements the interface types.RequestBodyHook", func() {
+		var i types.RequestBodyHook
+		o := Frontend{}
+		Expect(&o).To(ImplementInterface(&i))
+	})
+})
+
+var _ = Describe("Object LoadBalancer", func() {
+	It("implements the interface types.Object", func() {
+		var i types.Object
+		o := LoadBalancer{}
+		Expect(&o).To(ImplementInterface(&i))
+	})
+	It("implements the interface types.RequestBodyHook", func() {
+		var i types.RequestBodyHook
+		o := LoadBalancer{}
+		Expect(&o).To(ImplementInterface(&i))
+	})
+})

--- a/pkg/core/resource/api.go
+++ b/pkg/core/resource/api.go
@@ -2,10 +2,6 @@ package resource
 
 import (
 	"context"
-	genericAPI "github.com/anexia-it/go-anxcloud/pkg/api"
-	"github.com/anexia-it/go-anxcloud/pkg/api/types"
-	"github.com/go-logr/logr"
-	"net/url"
 
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 )
@@ -20,38 +16,6 @@ type API interface {
 
 type api struct {
 	client client.Client
-}
-
-func (i Info) EndpointURL(ctx context.Context) (*url.URL, error) {
-	u, err := url.ParseRequestURI(pathPrefix)
-	if err != nil {
-		return nil, err
-	}
-
-	op, err := types.OperationFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	switch op {
-	// OperationCreate is not supported because the API does not exist in the engine.
-	// OperationDestroy and OperationUpdate is not yet implemented
-	case types.OperationCreate, types.OperationDestroy, types.OperationUpdate:
-		return nil, genericAPI.ErrOperationNotSupported
-	}
-
-	if op == types.OperationList {
-		query := u.Query()
-
-		if len(i.Tags) > 1 {
-			logr.FromContextOrDiscard(ctx).Info("Listing with multiple tags isn't supported. Only first one used")
-		}
-
-		if len(i.Tags) > 0 {
-			query.Add("tag_name", i.Tags[0])
-		}
-		u.RawQuery = query.Encode()
-	}
-	return u, err
 }
 
 // NewAPI creates a new tags API instance with the given client.

--- a/pkg/core/resource/resource.go
+++ b/pkg/core/resource/resource.go
@@ -7,28 +7,21 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	v1 "github.com/anexia-it/go-anxcloud/pkg/apis/core/v1"
 )
 
 const pathPrefix = "/api/core/v1/resource.json"
+
+type (
+	Type = v1.Type
+	Info = v1.Info
+)
 
 // Summary describes a resource in short.
 type Summary struct {
 	Identifier string `json:"identifier"`
 	Name       string `json:"name"`
-}
-
-// Type is part of info.
-type Type struct {
-	Identifier string `json:"identifier"`
-	Name       string `json:"name"`
-}
-
-// Info contains all information about a resource.
-type Info struct {
-	Identifier string   `json:"identifier" anxcloud:"identifier"`
-	Name       string   `json:"name"`
-	Type       Type     `json:"resource_type"`
-	Tags       []string `json:"tags"`
 }
 
 type listResponse struct {

--- a/pkg/lbaas/backend/api.go
+++ b/pkg/lbaas/backend/api.go
@@ -2,9 +2,7 @@ package backend
 
 import (
 	"context"
-	"net/url"
 
-	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/anexia-it/go-anxcloud/pkg/pagination"
 )
@@ -26,46 +24,4 @@ type api struct {
 // NewAPI creates a new load balancer backend API instance with the given client.
 func NewAPI(c client.Client) API {
 	return &api{c}
-}
-
-// EndpointURL returns the URL where to retrieve objects of type Backend and the identifier of the given Backend.
-// It implements the api.Object interface on *Backend, making it usable with the generic API client.
-func (b *Backend) EndpointURL(ctx context.Context) (*url.URL, error) {
-	u, err := url.ParseRequestURI("/api/LBaaS/v1/backend.json")
-
-	if op, err := types.OperationFromContext(ctx); err == nil && op == types.OperationList {
-		filters := make(url.Values)
-
-		if b.LoadBalancer.Identifier != "" {
-			filters.Add("load_balancer", b.LoadBalancer.Identifier)
-		}
-
-		if b.Mode != "" {
-			filters.Add("mode", string(b.Mode))
-		}
-
-		query := u.Query()
-		query.Add("filters", filters.Encode())
-		u.RawQuery = query.Encode()
-	} else if err != nil {
-		return nil, err
-	}
-
-	return u, err
-}
-
-// FilterAPIRequestBody generates the request body for creating a new Backend, which differs from the Backend object.
-func (b *Backend) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
-	if op, err := types.OperationFromContext(ctx); err == nil && op == types.OperationCreate {
-		return map[string]string{
-			"name":          b.Name,
-			"load_balancer": b.LoadBalancer.Identifier,
-			"mode":          string(b.Mode),
-			"state":         "4", // "newly created"
-		}, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	return b, nil
 }

--- a/pkg/lbaas/backend/backend.go
+++ b/pkg/lbaas/backend/backend.go
@@ -10,29 +10,20 @@ import (
 	utils "path"
 	"strconv"
 
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/common"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/loadbalancer"
+	v1 "github.com/anexia-it/go-anxcloud/pkg/apis/lbaas/v1"
 )
 
 const (
 	path = "api/LBaaS/v1/backend.json"
 )
 
+// The Backend resource configures settings common for all specific backend Server resources linked to it.
+type Backend = v1.Backend
+
 // BackendInfo holds the identifier and the name of a load balancer backend.
 type BackendInfo struct {
 	Identifier string `json:"identifier" anxcloud:"identifier"`
 	Name       string `json:"name"`
-}
-
-type Backend struct {
-	CustomerIdentifier string                        `json:"customer_identifier"`
-	ResellerIdentifier string                        `json:"reseller_identifier"`
-	Identifier         string                        `json:"identifier" anxcloud:"identifier"`
-	Name               string                        `json:"name"`
-	LoadBalancer       loadbalancer.LoadBalancerInfo `json:"load_balancer"`
-	HealthCheck        string                        `json:"health_check"`
-	Mode               common.Mode                   `json:"mode"`
-	ServerTimeout      int                           `json:"server_timeout"`
 }
 
 func (a api) Get(ctx context.Context, page, limit int) ([]BackendInfo, error) {

--- a/pkg/lbaas/common/common.go
+++ b/pkg/lbaas/common/common.go
@@ -1,18 +1,21 @@
 package common
 
-type Mode string
-
-const (
-	TCP  = Mode("tcp")
-	HTTP = Mode("http")
+import (
+	v1 "github.com/anexia-it/go-anxcloud/pkg/apis/lbaas/v1"
 )
 
-type State string
+type (
+	Mode  = v1.Mode
+	State = v1.State
+)
 
 const (
-	Updating        = State("0")
-	Updated         = State("1")
-	DeploymentError = State("2")
-	Deployed        = State("3")
-	NewlyCreated    = State("4")
+	HTTP = v1.HTTP
+	TCP  = v1.TCP
+
+	Updating        = v1.Updating
+	Updated         = v1.Updated
+	DeploymentError = v1.DeploymentError
+	Deployed        = v1.Deployed
+	NewlyCreated    = v1.NewlyCreated
 )

--- a/pkg/lbaas/frontend/api.go
+++ b/pkg/lbaas/frontend/api.go
@@ -2,9 +2,7 @@ package frontend
 
 import (
 	"context"
-	"net/url"
 
-	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/anexia-it/go-anxcloud/pkg/pagination"
 )
@@ -26,25 +24,4 @@ type api struct {
 // NewAPI creates a new frontend API instance with the given client.
 func NewAPI(c client.Client) API {
 	return &api{c}
-}
-
-// EndpointURL returns the URL where to retrieve objects of type Frontend and the identifier of the given Frontend.
-// It implements the api.Object interface on *Frontend, making it usable with the generic API client.
-func (f *Frontend) EndpointURL(ctx context.Context, op types.Operation, options types.Options) (*url.URL, string, error) {
-	url, err := url.ParseRequestURI("/api/LBaaS/v1/frontend.json")
-	return url, f.Identifier, err
-}
-
-// FilterAPIRequestBody generates the request body for creating a new Frontend, which differs from the Frontend object.
-func (f *Frontend) FilterAPIRequestBody(op types.Operation, options types.Options) (interface{}, error) {
-	if op == types.OperationCreate {
-		return map[string]string{
-			"name":            f.Name,
-			"load_balancer":   f.LoadBalancer.Identifier,
-			"default_backend": f.DefaultBackend.Identifier,
-			"state":           "4", // "newly created"
-		}, nil
-	}
-
-	return f, nil
 }

--- a/pkg/lbaas/frontend/frontend.go
+++ b/pkg/lbaas/frontend/frontend.go
@@ -5,33 +5,23 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/backend"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/common"
-	"github.com/anexia-it/go-anxcloud/pkg/lbaas/loadbalancer"
 	"net/http"
 	"net/url"
 	utils "path"
 	"strconv"
+
+	v1 "github.com/anexia-it/go-anxcloud/pkg/apis/lbaas/v1"
 )
 
 const path = "api/LBaaS/v1/frontend.json"
+
+// Frontend represents a LBaaS Frontend.
+type Frontend = v1.Frontend
 
 // FrontendInfo holds the name and the identifier of a frontend
 type FrontendInfo struct {
 	Identifier string `json:"identifier"`
 	Name       string `json:"name"`
-}
-
-// Frontend represents a LBaaS Frontend.
-type Frontend struct {
-	CustomerIdentifier string                         `json:"customer_identifier"`
-	ResellerIdentifier string                         `json:"reseller_identifier"`
-	Identifier         string                         `json:"identifier"`
-	Name               string                         `json:"name"`
-	LoadBalancer       *loadbalancer.LoadBalancerInfo `json:"load_balancer,omitempty"`
-	DefaultBackend     *backend.BackendInfo           `json:"default_backend,omitempty"`
-	Mode               common.Mode                    `json:"mode"`
-	ClientTimeout      string                         `json:"client_timeout"`
 }
 
 func (a api) Get(ctx context.Context, page, limit int) ([]FrontendInfo, error) {

--- a/pkg/lbaas/loadbalancer/api.go
+++ b/pkg/lbaas/loadbalancer/api.go
@@ -2,9 +2,7 @@ package loadbalancer
 
 import (
 	"context"
-	"net/url"
 
-	"github.com/anexia-it/go-anxcloud/pkg/api/types"
 	"github.com/anexia-it/go-anxcloud/pkg/client"
 	"github.com/anexia-it/go-anxcloud/pkg/pagination"
 )
@@ -23,26 +21,4 @@ type api struct {
 // NewAPI creates a new load balancer API instance with the given client.
 func NewAPI(c client.Client) API {
 	return &api{c}
-}
-
-// EndpointURL returns the URL where to retrieve objects of type Loadbalancer and the identifier of the given Loadbalancer.
-// It implements the api.Object interface on *Loadbalancer, making it usable with the generic API client.
-func (lb *Loadbalancer) EndpointURL(ctx context.Context) (*url.URL, error) {
-	url, err := url.ParseRequestURI("/api/LBaaS/v1/loadbalancer.json")
-	return url, err
-}
-
-// FilterAPIRequestBody generates the request body for creating a new Loadbalancer, which differs from the Loadbalancer object.
-func (lb *Loadbalancer) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
-	if op, err := types.OperationFromContext(ctx); err == nil && op == types.OperationCreate {
-		return map[string]string{
-			"name":       lb.Name,
-			"ip_address": lb.IpAddress,
-			"state":      "2",
-		}, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	return lb, nil
 }

--- a/pkg/lbaas/loadbalancer/loadbalancer.go
+++ b/pkg/lbaas/loadbalancer/loadbalancer.go
@@ -8,10 +8,16 @@ import (
 	"net/url"
 	utils "path"
 	"strconv"
+
+	v1 "github.com/anexia-it/go-anxcloud/pkg/apis/lbaas/v1"
 )
 
-const (
-	path = "api/LBaaS/v1/loadbalancer.json"
+type (
+	// RuleInfo holds the name and identifier of a rule.
+	RuleInfo = v1.RuleInfo
+
+	// Loadbalancer holds the information of a load balancer instance.
+	Loadbalancer = v1.LoadBalancer
 )
 
 // LoadBalancerInfo holds the identifier and the name of a load balancer
@@ -20,23 +26,9 @@ type LoadBalancerInfo struct {
 	Name       string `json:"name"`
 }
 
-// RuleInfo holds the name and identifier of a rule.
-type RuleInfo struct {
-	Identifier string `json:"identifier" anxcloud:"identifier"`
-	Name       string `json:"name"`
-}
-
-// anxcloud:object:hooks=RequestBodyHook
-
-// Loadbalancer holds the information of a load balancer instance.
-type Loadbalancer struct {
-	CustomerIdentifier string     `json:"customer_identifier"`
-	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier" anxcloud:"identifier"`
-	Name               string     `json:"name"`
-	IpAddress          string     `json:"ip_address"`
-	AutomationRules    []RuleInfo `json:"automation_rules"`
-}
+const (
+	path = "api/LBaaS/v1/loadbalancer.json"
+)
 
 func (a api) Get(ctx context.Context, page, limit int) ([]LoadBalancerInfo, error) {
 	endpoint, err := url.Parse(a.client.BaseURL())


### PR DESCRIPTION
### Description

This makes much more visible which APIs are supported by the generic client, makes it easier to have generic client supporting APIs not sharing any code with existing old clients and is a place where other big projects place their API definitions.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* NONE (unreleased feature)
```

### References
* for generic client introduced in #56 
* moves core/resources API built in #67 

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
