### PR TITLE
👽️: add State member to lbaas/LoadBalancer

### DIFF
--- a/pkg/apis/lbaas/v1/loadbalancer_types.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_types.go
@@ -1,5 +1,12 @@
 package v1
 
+// LoadBalancerState describes the status of a given LoadBalancer
+type LoadBalancerState struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+	Type int    `json:"type"`
+}
+
 // RuleInfo holds the name and identifier of a rule.
 type RuleInfo struct {
 	Identifier string `json:"identifier" anxcloud:"identifier"`
@@ -10,10 +17,11 @@ type RuleInfo struct {
 
 // LoadBalancer holds the information of a load balancer instance.
 type LoadBalancer struct {
-	CustomerIdentifier string     `json:"customer_identifier"`
-	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier" anxcloud:"identifier"`
-	Name               string     `json:"name"`
-	IpAddress          string     `json:"ip_address"`
-	AutomationRules    []RuleInfo `json:"automation_rules"`
+	CustomerIdentifier string            `json:"customer_identifier"`
+	ResellerIdentifier string            `json:"reseller_identifier"`
+	Identifier         string            `json:"identifier" anxcloud:"identifier"`
+	Name               string            `json:"name"`
+	IpAddress          string            `json:"ip_address"`
+	AutomationRules    []RuleInfo        `json:"automation_rules"`
+	State              LoadBalancerState `json:"state"`
 }


### PR DESCRIPTION
### Description

Currently we have `DisallowUnknownFields` enabled in the generic client, which requires us to have all API response fields in our Go types. This adds the state attribute to the lbaasv1.LoadBalancer type.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* add State attribute to Loadbalancer type
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
