### PR TITLE
Fix template build sorting in tests

### DIFF
--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -45,17 +45,16 @@ const (
 var templateID string
 
 // This versioning scheme that currently seems to be in place for template build numbers.
-var buildNumberRegex = regexp.MustCompile(`[bB]?(?P<version>\d+)`)
+var buildNumberRegex = regexp.MustCompile(`[bB]?(\d+)`)
 
-func getBuildNumberFromString(build string) int {
-	index := buildNumberRegex.SubexpIndex("build")
+func extractBuildNumber(build string) int {
 	matches := buildNumberRegex.FindStringSubmatch(build)
 	if len(matches) == 0 {
 		// panic here since someone needs to check on the regex
 		panic("build does not match the buildNumberRegex")
 	}
 
-	number, err := strconv.ParseInt(matches[index], 10, 0)
+	number, err := strconv.ParseInt(matches[0], 10, 0)
 	if err != nil {
 		panic(fmt.Sprintf("could not extract build for %s: %s", build, err.Error()))
 	}
@@ -84,7 +83,7 @@ func vsphereTestInit() {
 	}
 
 	sort.Slice(selected, func(i, j int) bool {
-		return getBuildNumberFromString(selected[i].Build) > getBuildNumberFromString(selected[j].Build)
+		return extractBuildNumber(selected[i].Build) > extractBuildNumber(selected[j].Build)
 	})
 
 	log.Printf("VSphere: selected template %v (build %v, ID %v)\n", selected[0].Name, selected[0].Build, selected[0].ID)


### PR DESCRIPTION
### Description

For proper version sorting we need to extract the number from the `build` property of a template. The `build` Property is currently not enforcing any format however there is at least some kind of convention that I tried to put in a regex.


### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
None 
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
