### PR TITLE
Some LBaaS generic client fixes

### DIFF
--- a/pkg/apis/lbaas/v1/backend_types.go
+++ b/pkg/apis/lbaas/v1/backend_types.go
@@ -4,13 +4,15 @@ package v1
 
 // The Backend resource configures settings common for all specific backend Server resources linked to it.
 type Backend struct {
-	CustomerIdentifier string `json:"customer_identifier"`
-	ResellerIdentifier string `json:"reseller_identifier"`
-	Identifier         string `json:"identifier" anxcloud:"identifier"`
-	Name               string `json:"name"`
-	HealthCheck        string `json:"health_check"`
-	Mode               Mode   `json:"mode"`
-	ServerTimeout      int    `json:"server_timeout"`
+	CustomerIdentifier string      `json:"customer_identifier"`
+	ResellerIdentifier string      `json:"reseller_identifier"`
+	Identifier         string      `json:"identifier" anxcloud:"identifier"`
+	Name               string      `json:"name"`
+	HealthCheck        string      `json:"health_check"`
+	Mode               Mode        `json:"mode"`
+	ServerTimeout      int         `json:"server_timeout"`
+	State              StateObject `json:"state"`
+	AutomationRules    []RuleInfo  `json:"automation_rules"`
 
 	// Only the name and identifier fields are used and returned.
 	LoadBalancer LoadBalancer `json:"load_balancer"`

--- a/pkg/apis/lbaas/v1/frontend_genclient.go
+++ b/pkg/apis/lbaas/v1/frontend_genclient.go
@@ -10,8 +10,30 @@ import (
 // EndpointURL returns the URL where to retrieve objects of type Frontend and the identifier of the given Frontend.
 // It implements the api.Object interface on *Frontend, making it usable with the generic API client.
 func (f *Frontend) EndpointURL(ctx context.Context) (*url.URL, error) {
-	url, err := url.ParseRequestURI("/api/LBaaS/v1/frontend.json")
-	return url, err
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	u, err := url.ParseRequestURI("/api/LBaaS/v1/frontend.json")
+
+	if op == types.OperationList {
+		filters := make(url.Values)
+
+		if f.LoadBalancer.Identifier != "" {
+			filters.Add("load_balancer", f.LoadBalancer.Identifier)
+		}
+
+		if f.Mode != "" {
+			filters.Add("mode", string(f.Mode))
+		}
+
+		query := u.Query()
+		query.Add("filters", filters.Encode())
+		u.RawQuery = query.Encode()
+	}
+
+	return u, err
 }
 
 // FilterAPIRequestBody generates the request body for creating a new Frontend, which differs from the Frontend object.

--- a/pkg/apis/lbaas/v1/frontend_types.go
+++ b/pkg/apis/lbaas/v1/frontend_types.go
@@ -4,12 +4,14 @@ package v1
 
 // Frontend represents a LBaaS Frontend.
 type Frontend struct {
-	CustomerIdentifier string `json:"customer_identifier"`
-	ResellerIdentifier string `json:"reseller_identifier"`
-	Identifier         string `json:"identifier"`
-	Name               string `json:"name"`
-	Mode               Mode   `json:"mode"`
-	ClientTimeout      string `json:"client_timeout"`
+	CustomerIdentifier string      `json:"customer_identifier"`
+	ResellerIdentifier string      `json:"reseller_identifier"`
+	Identifier         string      `json:"identifier" anxcloud:"identifier"`
+	Name               string      `json:"name"`
+	Mode               Mode        `json:"mode"`
+	ClientTimeout      string      `json:"client_timeout"`
+	State              StateObject `json:"state"`
+	AutomationRules    []RuleInfo  `json:"automation_rules"`
 
 	// Only the name and identifier fields are used and returned.
 	LoadBalancer *LoadBalancer `json:"load_balancer,omitempty"`

--- a/pkg/apis/lbaas/v1/loadbalancer_types.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_types.go
@@ -1,27 +1,14 @@
 package v1
 
-// LoadBalancerState describes the status of a given LoadBalancer
-type LoadBalancerState struct {
-	ID   string `json:"id"`
-	Text string `json:"text"`
-	Type int    `json:"type"`
-}
-
-// RuleInfo holds the name and identifier of a rule.
-type RuleInfo struct {
-	Identifier string `json:"identifier" anxcloud:"identifier"`
-	Name       string `json:"name"`
-}
-
 // anxcloud:object:hooks=RequestBodyHook
 
 // LoadBalancer holds the information of a load balancer instance.
 type LoadBalancer struct {
-	CustomerIdentifier string            `json:"customer_identifier"`
-	ResellerIdentifier string            `json:"reseller_identifier"`
-	Identifier         string            `json:"identifier" anxcloud:"identifier"`
-	Name               string            `json:"name"`
-	IpAddress          string            `json:"ip_address"`
-	AutomationRules    []RuleInfo        `json:"automation_rules"`
-	State              LoadBalancerState `json:"state"`
+	CustomerIdentifier string      `json:"customer_identifier"`
+	ResellerIdentifier string      `json:"reseller_identifier"`
+	Identifier         string      `json:"identifier" anxcloud:"identifier"`
+	Name               string      `json:"name"`
+	IpAddress          string      `json:"ip_address"`
+	AutomationRules    []RuleInfo  `json:"automation_rules"`
+	State              StateObject `json:"state"`
 }

--- a/pkg/apis/lbaas/v1/types.go
+++ b/pkg/apis/lbaas/v1/types.go
@@ -16,3 +16,20 @@ const (
 	Deployed        = State("3")
 	NewlyCreated    = State("4")
 )
+
+// StateObject describes the status of a given resource, including programatic usable and human readable values.
+type StateObject struct {
+	// programatically usable enum value
+	ID State `json:"id"`
+
+	// human readable status text
+	Text string `json:"text"`
+
+	Type int `json:"type"`
+}
+
+// RuleInfo holds the name and identifier of a rule.
+type RuleInfo struct {
+	Identifier string `json:"identifier" anxcloud:"identifier"`
+	Name       string `json:"name"`
+}

--- a/pkg/apis/lbaas/v1/types.go
+++ b/pkg/apis/lbaas/v1/types.go
@@ -1,20 +1,22 @@
 package v1
 
+// Mode is an enum for the supported LoadBalancer protocols.
 type Mode string
 
 const (
-	TCP  = Mode("tcp")
-	HTTP = Mode("http")
+	TCP  Mode = "tcp"
+	HTTP Mode = "http"
 )
 
+// State is an enum to describe the current status of some object.
 type State string
 
 const (
-	Updating        = State("0")
-	Updated         = State("1")
-	DeploymentError = State("2")
-	Deployed        = State("3")
-	NewlyCreated    = State("4")
+	Updating        State = "0"
+	Updated         State = "1"
+	DeploymentError State = "2"
+	Deployed        State = "3"
+	NewlyCreated    State = "4"
 )
 
 // StateObject describes the status of a given resource, including programatic usable and human readable values.


### PR DESCRIPTION
### Description

This fixes some problems in the generic client code for LBaaS:
* Frontend wasn't a valid object (missing `anxcloud:"identifier"` tag)
* Backend and Frontend have State and AutomationRules, too

Also adds support for filtering Frontends on LoadBalancer and mode and slightly improves docs.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use a format like

* <api-scope>[/<sub-api-scope] - <a short description of what changed>

e.g.

* vsphere/provisioning - added progress identifier

-->

```release-note
NONE (update to unreleased feature)
```

### References
* problems where found while doing #90 
* generic client introduced in #56
  * LBaaS support for generic client was built as first test case there
* we need these fields added due to problem described in [SYSENG-753 (internal only)](https://ats.anexia-it.com/browse/SYSENG-753)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
