### PR TITLE
use correct capture group index

### DIFF
--- a/tests/vsphere_test.go
+++ b/tests/vsphere_test.go
@@ -49,12 +49,12 @@ var buildNumberRegex = regexp.MustCompile(`[bB]?(\d+)`)
 
 func extractBuildNumber(build string) int {
 	matches := buildNumberRegex.FindStringSubmatch(build)
-	if len(matches) == 0 {
+	if len(matches) != 2 {
 		// panic here since someone needs to check on the regex
 		panic("build does not match the buildNumberRegex")
 	}
 
-	number, err := strconv.ParseInt(matches[0], 10, 0)
+	number, err := strconv.ParseInt(matches[1], 10, 0)
 	if err != nil {
 		panic(fmt.Sprintf("could not extract build for %s: %s", build, err.Error()))
 	}
@@ -278,7 +278,14 @@ var _ = Describe("vsphere API endpoint tests", func() {
 
 		})
 	})
+})
 
+var _ = Describe("build number parsing for templates", func() {
+	It("extracting build number from string", func() {
+		Expect(extractBuildNumber("b5555")).To(BeEquivalentTo(5555))
+		Expect(extractBuildNumber("B111")).To(BeEquivalentTo(111))
+		Expect(extractBuildNumber("123")).To(BeEquivalentTo(123))
+	})
 })
 
 func randomPublicSSHKey() string {


### PR DESCRIPTION
### Description

When discovering the latest template, the wrong capture group was used, since the first match always contains the whole match.
Also added tests so that something like this doesn't happen again if the regex needs to be changed in the future

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use a format like

* <api-scope>[/<sub-api-scope] - <a short description of what changed>

e.g.

* vsphere/provisioning - added progress identifier

-->

```release-note
NONE
```
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
