### PR TITLE
Restructure and reformat docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,23 +2,9 @@
 
 <!--- Please leave a helpful description of the pull request here. --->
 
-### Release Note
-Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
-<!--
-If change is not user facing, just write "NONE" in the release-note block below.
-Otherwise use a format like
+### Checklist
 
-* <api-scope>[/<sub-api-scope] - <a short description of what changed>
-
-e.g.
-
-* vsphere/provisioning - added progress identifier
-
--->
-
-```release-note
-
-```
+* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change
 
 ### References
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,76 +1,61 @@
-## 0.3.28
+# Changelog
 
-ENHANCEMENTS
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.28] - 2021-10-05
+### Added
 * ipam/prefix - allow to create empty prefixes
 * ipam/address - allow to retrieve addresses with given filters
 
-## 0.3.27
-
-ENHANCEMENTS
-
+## [0.3.27] - 2021-09-27
+### Added
 *  ipam/prefix - Prefix Type is now available in Info
 
-## 0.3.26
-
-ENHANCEMENTS
-
+## [0.3.26] - 2021-09-23
+### Added
 *  vsphere - Deprovision now returns progress identifier
 
-## 0.3.25
-
-ENHANCEMENTS
-
+## [0.3.25] - 2021-09-22
+### Added
 * lbaas - add load balancer as a service endpoints
 * lbaas - add acl endpoints
 * client - allow to specify a user agent option
 
-## 0.3.24
-
-ENHANCEMENTS
-
+## [0.3.24] - 2021-08-23
+### Added
 * vsphere/progress Fix a bug where 404 from progress API results in a loop until timeout
 
-## 0.3.23
-
-ENHANCEMENTS
-
+## [0.3.23] - 2021-08-12
+### Added
 * vmlist - Added VMList API client
 
-## 0.3.22
-
-ENHANCEMENTS
-
+## [0.3.22] - 2021-07-20
+### Added
 * clouddns - Added CloudDNS API client
 
-## 0.3.21
-
-ENHANCEMENTS
-
+## [0.3.21] - 2021-07-17
+### Added
 * client - Add client option to provide an `io.Writer` to dump http request/response for debugging
 
-## 0.3.20
-
-BUGFIXES
-
+## [0.3.20] - 2021-04-07
+### Fixed
 * vsphere/info - `DiskGB` variable type changed from float32 to float64
 
-## 0.3.19
-
-ENHANCEMENTS
-
+## [0.3.19] - 2021-03-29
+### Added
 * vlan - added `vm_provisioning` flag to `UpdateDefinition`
 * vsphere/info - `DiskGB` attribute changed to floating point type
 * ipam/address - random sleep added to ip reservation as workaround
 
-## 0.3.18
-
-BUGFIXES
-
+## [0.3.18] - 2021-03-22
+### Fixed
 * Changed location identifier tag name
 
-## 0.3.17
-
-BUGFIXES  
-
+## [0.3.17] - 2021-03-19
+### Fixed
 * Added multi VLAN support to ip-prefix. (#19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!--
+Please add your release notes under the correct category (Added, Changed, ...) and use the following format as a
+guideline:
+
+* <api-scope>[/<sub-api-scope] - <a short description of what changed>
+
+e.g.
+
+* vsphere/provisioning - added progress identifier
+-->
+
+### Added
+* new client, unifying features across APIs and reducing code duplication (PR #56)
+  - already supported:
+    + core/resources
+    + lbaas
+    + clouddns/zone
+* client: new option `BaseURL` (PR #58)
+* client: interface to retrieve metrics, such as requests currently in-flight or request duration (PR #66)
+* old-style clients:
+  - lbaas: pagination support (PR #45)
+  - core/location: add getters for locations by identifier and code (PR #49)
+  - vsphere/info: add CPU performance type and CPU clock rate attributes (PR #51)
+
+### Changed
+* client: now uses [`logr`](https://github.com/go-logr/logr) for logging (PR #50)
+* package is now tested against Go versions 1.16 and 1.17
+
+### Deprecated
+* the old-style clients are deprecated and will be removed in the minor version following the version with everything supported by the generic client we have old-style clients for
+  - write code against the generic client instead, create issues for APIs you need to help us prioritize them
+* client: the `LogWriter` option for dumping requests and responses is replaced by the `Logger` option (PR #50)
+
+### Removed
+* client: DefaultBaseURL was exported by mistake and is not exposed anymore, use the BaseURL method on the client instance instead (PR #58)
+
+### Fixed
+* connections could end up dangling around (PR #48)
+
 ## [0.3.28] - 2021-10-05
 ### Added
 * ipam/prefix - allow to create empty prefixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Guidance on how to contribute
+
+> By submitting a pull request or filing a bug, issue, or feature request,
+> you are agreeing to comply with this waiver of copyright interest.
+> Details can be found in our [LICENSE](LICENSE).
+
+
+There are two primary ways to help:
+ - Using the issue tracker, and
+ - Changing the code-base.
+
+
+## Using the issue tracker
+
+Use the issue tracker to suggest feature requests, report bugs, and ask questions.
+This is also a great way to connect with the developers of the project as well
+as others who are interested in this solution.
+
+Use the issue tracker to find ways to contribute. Find a bug or a feature, mention in
+the issue that you will take on that effort, then follow the _Changing the code-base_
+guidance below.
+
+
+## Changing the code-base
+
+Generally speaking, you should fork this repository, make changes in your
+own fork, and then submit a pull request. All new code should have associated
+unit tests that validate implemented features and the presence or lack of defects.
+Additionally, the code should follow any stylistic and architectural guidelines
+prescribed by the project. In the absence of such guidelines, mimic the styles
+and patterns in the existing code-base.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,16 +16,94 @@ Use the issue tracker to suggest feature requests, report bugs, and ask question
 This is also a great way to connect with the developers of the project as well
 as others who are interested in this solution.
 
-Use the issue tracker to find ways to contribute. Find a bug or a feature, mention in
-the issue that you will take on that effort, then follow the _Changing the code-base_
-guidance below.
+You can also use it to find a bug to fix or feature to implement. Mention in
+the issue that you want to work on it (to prevent multiple people working on the same),
+then follow the _Changing the code-base_ guidance below.
 
 
 ## Changing the code-base
 
 Generally speaking, you should fork this repository, make changes in your
-own fork, and then submit a pull request. All new code should have associated
-unit tests that validate implemented features and the presence or lack of defects.
-Additionally, the code should follow any stylistic and architectural guidelines
-prescribed by the project. In the absence of such guidelines, mimic the styles
-and patterns in the existing code-base.
+own fork, and then submit a pull request. People having commit access on this repository can
+also push their branches in this repository instead of a fork, but still have to open pull
+requests to have things merged into `main`.
+
+All new code should have associated unit tests that validate implemented features
+and the presence or lack of defects. For tests we use [`ginkgo`](https://onsi.github.io/ginkgo/)
+and [`gomega`](https://onsi.github.io/gomega/), maybe take a look at
+[`pkg/api/errors_test.go`](pkg/api/errors_test.go) for an example on how we use it.
+
+Code in this project follows the standard go code style (`go fmt`), our CI system enforces it.
+Please add new code in a sensible location, using the trimmed-down tree below as a guideline.
+
+```plain
+- pkg
++-- api         Generic client for our API
+| +-- types     Things needed to implement Objects compatible with the generic client
+|
++-- apis        Base for APIs usable with the generic client
+| |
+| +-- lbaas     Types and supporting code for multiple versions of LBaaS API
+| | +-- v1      Types and supporting code for using LBaaS API v1 with the generic client
+| |
+| +-- clouddns  Types and supporting code for multiple versions of CloudDNS API
+|   +-- v1      Types and supporting code for using CloudDNS API v1 with the generic client
+|
++-- client      Wrapper around http.Client adding logging, authentication, ...
+|
++-- utils       Utilities used in more than one package
+  +-- test      Utilities for testing things
+```
+
+There are a lot more packages in this repository, many for the legacy clients. There is also the
+`tests` directory in the repository root, containing the old integration tests not yet moved into
+their packages. This tree is supposed to be an example and guideline, not a full list of everything
+in the project.
+
+
+### pre-commit hook
+
+There is a `pre-commit` hook checking some things before you even make a commit, you can install it with
+`make install-precommit-hook`. It might occasionally warn you about it being not up to date, run that command
+again to update it.
+
+It's not very clever yet and in some cases might hinder working, for example when rebasing. You can always just
+uninstall it with `rm .git/hooks/pre-commit`.
+
+
+## Testing
+
+We use `Ginkgo` (v2) for our tests. Unit and integration tests are both directly in the package they test, integration
+tests are disabled by default with build tags, like this:
+
+```go
+//go:build integration
+// +build integration
+
+package foo
+```
+
+Integration tests for bigger scopes (in a package and testing integration of sub-packages together) are placed in the
+matching higher hierarchy package (e.g.: test basics in `pkg/vsphere/provisioning/disktype` and test whole "create VM
+and do things with it" in `pkg/vsphere`).
+
+Tests are executed with either `make test` (for unit tests) or `make func-test` (for e2e/integration tests). Note the
+integration tests need an authentication token in environment variable `ANEXIA_TOKEN`.
+
+To run unit tests for a single package or everything below a given package you can use either `go test ./pkg/lbaas/acl`
+(for testing only acl package) or `go test ./pkg/lbaas/...` (for testing everything below ./pkg/lbaas, including the
+`lbaas` package itself). For running integration tags, add the build tag like `go test -tags integration ./pkg/lbaas/...`.
+You can also use the `ginkgo` CLI tool `ginkgo -tags integration pkg/lbaas/...`.
+
+
+### Code generator
+
+We use a code generator to automate some manual work. Currently it's only used to generate tests making sure
+and `Object` (something you can use with the generic client) really implements hooks. It works by adding some
+magic comments in the format `// anexia:something:something-else=foo,bar`.
+
+Whenever you touch such a comment, something tagged with such a comment or the code generator itself you have
+to update the generated code by running `make generate` and commit it together with your changes. The CI will
+bark at you when you forget this (but we won't, promise).
+
+More info about this can be found in [its documentation](docs/code-generator.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,13 @@
 > you are agreeing to comply with this waiver of copyright interest.
 > Details can be found in our [LICENSE](LICENSE).
 
-
 There are two primary ways to help:
  - Using the issue tracker, and
  - Changing the code-base.
+
+If you found something you believe is a (possible) security issue, please do not hesitate
+to contact us via the information in [SECURITY.md](SECURITY.md). Do not open an issue for
+that, as it would be public and put users at risk.
 
 
 ## Using the issue tracker

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 ANX
+   Copyright 2022 ANX
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Go Client for the Anexia API
 
-Go SDK for interacting with the Anexia multi purpose [API](https://engine.anexia-it.com/).
+Go SDK for interacting with the Anexia Engine [API](https://engine.anexia-it.com/).
 
 ## Installing
 
@@ -11,10 +11,11 @@ To use the SDK, just add `github.com/anexia-it/go-anxcloud <version>` to your Go
 
 ## Getting started
 
-Before using the SDK you should familiarize yourself with the API. See [here](https://engine.anexia-it.com/docs/) for more info.
-I you crave for an example, take a look at [the terraform provider for this project](https://github.com/anexia-it/terraform-provider-anxcloud)
+Before using the SDK you should familiarize yourself with the [Anexia Engine API](https://engine.anexia-it.com/docs/).
 
-## Example
+The library is used in [our terraform provider](https://github.com/anexia-it/terraform-provider-anxcloud), check it out if you want some examples how to use it.
+
+### Example
 
 Below is a short example using the new generic client in this package. Not all APIs can already be used with it, but we are working on that.
 Find [more examples in the docs](https://pkg.go.dev/github.com/anexia-it/go-anxcloud@main/pkg/api#example-package-Usage) (linked to docs for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting Security Issues
+
+Please report any security issues you discovered to opensource[at]anexia-it[dot]com
+
+We will assess the risk, plus make a fix available before we create a GitHub issue.
+
+Thank you for your contribution.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,12 @@
 # Reporting Security Issues
 
-Please report any security issues you discovered to opensource[at]anexia-it[dot]com
+Please report security issues via email to opensource [at] anexia-it [dot] com. Never use the issue tracker,
+as this would put users at risk by publishing the vulnerability before it is fixed.
 
-We will assess the risk, plus make a fix available before we create a GitHub issue.
+We will get in touch with you shortly, keeping you in the loop about our findings to your discovery. When we
+found and implemented a fix, we will document the problem in the changelog, crediting you (if you want, with
+a name you tell us to use). We will also gladly link to a blog post or similar related to the issue you reported.
 
-Thank you for your contribution.
+Sadly we can not generally offer monetary compensation at this point.
+
+Thank you for your help in making the internet more secure.

--- a/docs/code-generator.md
+++ b/docs/code-generator.md
@@ -1,31 +1,4 @@
-# Dev workflows
-
-## Testing
-
-We use `Ginkgo` (v2) for our tests. Unit and integration tests are both directly in the package they test, integration
-tests are disabled by default with build tags, like this:
-
-```go
-//go:build integration
-// +build integration
-
-package foo
-```
-
-Integration tests for bigger scopes (in a package and testing integration of sub-packages together) are placed in the
-matching higher hierarchy package (e.g.: test basics in `pkg/vsphere/provisioning/disktype` and test whole "create VM
-and do things with it" in `pkg/vsphere`).
-
-Tests are executed with either `make test` (for unit tests) or `make func-test` (for e2e/integration tests). Note the
-integration tests need an authentication token in environment variable `ANEXIA_TOKEN`.
-
-To run unit tests for a single package or everything below a given package you can use either `go test ./pkg/lbaas/acl`
-(for testing only acl package) or `go test ./pkg/lbaas/...` (for testing everything below ./pkg/lbaas, including the
-`lbaas` package itself). For running integration tags, add the build tag like `go test -tags integration ./pkg/lbaas/...`.
-You can also use the `ginkgo` CLI tool `ginkgo -tags integration pkg/lbaas/...`.
-
-
-## Code generator
+# Code generator
 
 Our build tools include a small code generator, currently only used to help with some tasks related to `Object`s,
 the interface needed to be compatible with the generic client. It's code lives in `/tools/object_generator.go`.
@@ -40,14 +13,14 @@ Only files with names not starting with `.`, ending with `.go` and not ending wi
 translates to every non-hidden non-test go file.
 
 
-### Workflow & CI
+## Workflow & CI
 
 When changing anything on a magic comment, a type marked with a magic comment or the code generator itself, you
 have to run `make generate` to re-generate files. The CI will check if `make generate` changes anything, failing
 if something was changed influencing the generated code without re-generating it.
 
 
-### Magic comment format
+## Magic comment format
 
 Comments always start with `// anxcloud:`, that's what the generator is looking for. Single space required between the
 comment-starting `//` and `anxcloud:`. To process the comment, this common prefix is stripped from it.
@@ -91,7 +64,7 @@ This example makes sure the type `LoadBalancer` does everything necessary to be 
 (`object` spec) and always implements the interface for the `ResponseBodyHook` correctly.
 
 
-#### Known specs and their usage
+### Known specs and their usage
 
 * `object`
 
@@ -109,12 +82,3 @@ This example makes sure the type `LoadBalancer` does everything necessary to be 
     | types     | names of hook interfaces from `pkg/api/types` |
 
     Explicitly specifies the type implements the given interfaces.
-
-## pre-commit hook
-
-There is a `pre-commit` hook checking some things before you even make a commit, you can install it with
-`make install-precommit-hook`. It might occasionally warn you about it being not up to date, run that command
-again to update it.
-
-It's not very clever yet and in some cases might hinder working, for example when rebasing. You can always just
-uninstall it with `rm .git/hooks/pre-commit`.


### PR DESCRIPTION
### Description

This restructures the contribution/dev-workflow docs and adds/reformats documents we have in our OpenSource repository template.

When reviewing this, best look at it commit for commit to have a much better overview what is changing.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use a format like

* <api-scope>[/<sub-api-scope] - <a short description of what changed>

e.g.

* vsphere/provisioning - added progress identifier

-->

```release-note
NONE
```

### References
* [SYSENG-682](https://ats.anexia-it.com/browse/SYSENG-682)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
