### PR TITLE
Upgrade to go 1.16 and document target version

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -14,9 +14,19 @@ env:
 jobs:
   go-lint:
     runs-on: ubuntu-latest
-    container: golang:1.15-buster
+    strategy:
+      matrix:
+        go:
+        - version: "1.16"
+          name: target
+        - version: "1.17"
+          name: latest
+    name: "Linting with ${{ matrix.go.name }} Go"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go.version }}
       - name: run linters
         run: |
           make tools
@@ -24,9 +34,19 @@ jobs:
           make fmtcheck
   codegen-uptodate:
     runs-on: ubuntu-latest
-    container: golang:1.15-buster
+    strategy:
+      matrix:
+        go:
+        - version: "1.16"
+          name: target
+        - version: "1.17"
+          name: latest
+    name: "Code generator with ${{ matrix.go.name }} Go"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go.version }}
       - name: generate code
         run:  |
           make generate

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -11,7 +11,18 @@ on:
 jobs:
   go-mod:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+        - version: "1.16"
+          name: target
+        - version: "1.17"
+          name: latest
+    name: "Dependency check with ${{ matrix.go.name }} Go"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go.version }}
       - name: run depscheck
         run: make depscheck

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -22,9 +22,19 @@ jobs:
         args: 'docs'
   misspell:
     runs-on: ubuntu-latest
-    container: golang:1.14-stretch
+    strategy:
+      matrix:
+        go:
+        - version: "1.16"
+          name: target
+        - version: "1.17"
+          name: latest
+    name: "Spell check with ${{ matrix.go.name }} Go"
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go.version }}
     - run: |
-        go install github.com/client9/misspell/cmd/misspell
-        misspell -error -source text docs/
+        make tools
+        make docs-lint

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,9 +16,20 @@ jobs:
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       || github.event_name == 'push' 
+    strategy:
+      matrix:
+        go:
+        - version: "1.16"
+          name: target
+        - version: "1.17"
+          name: latest
+    name: "Integration tests with ${{ matrix.go.name }} Go (trusted)"
     steps:
       - name: Branch based PR checkout
         uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go.version }}
       - name: run integration tests
         env:
           ANEXIA_TOKEN: ${{ secrets.ANEXIA_TOKEN }}
@@ -38,11 +49,22 @@ jobs:
       github.event_name == 'repository_dispatch' &&
       github.event.client_payload.slash_command.sha != '' &&
       contains(github.event.client_payload.pull_request.head.sha, github.event.client_payload.slash_command.sha)
+    strategy:
+      matrix:
+        go:
+        - version: "1.16"
+          name: target
+        - version: "1.17"
+          name: latest
+    name: "Integration tests with ${{ matrix.go.name }} Go (ok-to-test)"
     steps:
       - name: Fork based /ok-to-test checkout
         uses: actions/checkout@v2
         with:
           ref: 'refs/pull/${{ github.event.client_payload.pull_request.number }}/merge'
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go.version }}
       - name: run integration tests
         env:
           ANEXIA_TOKEN: ${{ secrets.ANEXIA_TOKEN }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,8 +9,19 @@ on:
 jobs:
   unit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+        - version: "1.16"
+          name: target
+        - version: "1.17"
+          name: latest
+    name: "Unit tests with ${{ matrix.go.name }} Go"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go.version }}
       - name: run unit tests
         run: make test
       - name: Upload coverage to Codecov

--- a/docs/go-versions.md
+++ b/docs/go-versions.md
@@ -1,0 +1,7 @@
+# Supported Go versions
+
+We follow Go's release policy, meaning we target its latest minor version and the minor version before
+(at the time of writing the latest version is 1.17, so we target 1.16 as minimum version).
+
+While we don't randomly upgrade the minimum Go version required to use this package, we upgrade whenever we
+want or need a feature from the newer version.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anexia-it/go-anxcloud
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
### Description

This changes the minimum Go version of this package to 1.16, the minimal currently supported version of Go, and adds documentation how we are going to lift the minimum Go version required by this package.

Also changes the GitHub actions workflows to matrix-test two Go versions, currently 1.16 and 1.17.

### Release Note
Release note for [CHANGELOG](https://github.com/anexia-it/go-anxcloud/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
Otherwise use a format like

* <api-scope>[/<sub-api-scope] - <a short description of what changed>

e.g.

* vsphere/provisioning - added progress identifier

-->

```release-note
* now requiring at least Go 1.16
```

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
