### PR TITLE
✅🩹: allow unknown fields in most responses

### DIFF
--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -483,11 +483,7 @@ func decodeResponse(ctx context.Context, mediaType string, data io.Reader, res i
 			return nil
 		}
 
-		d := json.NewDecoder(data)
-		// we have to disallow unknown fields since golangs json decoder does not have a way to specify required
-		// fields, meaning any json object can be decoded into any go struct.
-		d.DisallowUnknownFields()
-		return d.Decode(res)
+		return json.NewDecoder(data).Decode(res)
 	}
 
 	return fmt.Errorf("%w: no idea how to handle media type %v", ErrUnsupportedResponseFormat, mediaType)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1071,10 +1071,7 @@ func (o *context_test_object) FilterAPIRequestBody(ctx context.Context) (interfa
 func (o *context_test_object) DecodeAPIResponse(ctx context.Context, data io.Reader) error {
 	o.checkContext(true, ctx)
 	o.responseBodyCalled = true
-
-	d := json.NewDecoder(data)
-	d.DisallowUnknownFields()
-	return d.Decode(o)
+	return json.NewDecoder(data).Decode(o)
 }
 
 var _ = Describe("context passed to Object methods", func() {

--- a/pkg/api/object_example_test.go
+++ b/pkg/api/object_example_test.go
@@ -94,11 +94,8 @@ func (h *ExampleObjectMockHandler) ServeHTTP(res http.ResponseWriter, req *http.
 
 	switch req.URL.Path {
 	case "/example/v1":
-		d := json.NewDecoder(req.Body)
-		d.DisallowUnknownFields()
-
 		o := ExampleObject{}
-		_ = d.Decode(&o)
+		_ = json.NewDecoder(req.Body).Decode(&o)
 
 		o.Identifier = "some random identifier"
 		_ = json.NewEncoder(res).Encode(o)

--- a/pkg/api/pagination_test.go
+++ b/pkg/api/pagination_test.go
@@ -46,8 +46,6 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 				case 2:
 					return json.RawMessage(`-öasjfn.ksdjfbksdnmf, sdf`), nil
 				case 3:
-					return json.RawMessage(`[{ "error": "random garbage data returned" }]`), nil
-				case 4:
 					expectedPage++
 					return afterErrorResponse, nil
 				}
@@ -130,8 +128,6 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 						Expect(err.Error()).To(ContainSubstring("Server error"))
 					case 2:
 						Expect(err).To(MatchError(ErrPageResponseNotSupported))
-					case 3:
-						Expect(err.Error()).To(ContainSubstring("unknown field \"error\""))
 					}
 
 					Expect(pi.Next(&out)).To(BeFalse())
@@ -146,7 +142,7 @@ var _ = Describe("PageInfo implementation pageIter", func() {
 			}
 
 			Expect(pi.Error()).NotTo(HaveOccurred())
-			Expect(expectedError).To(Equal(3))
+			Expect(expectedError).To(Equal(2))
 		})
 	}
 

--- a/pkg/apis/clouddns/v1/xxgenerated_object_test.go
+++ b/pkg/apis/clouddns/v1/xxgenerated_object_test.go
@@ -32,11 +32,6 @@ var _ = Describe("Object Zone", func() {
 		o := Zone{}
 		Expect(&o).To(ImplementInterface(&i))
 	})
-	It("implements the interface types.ResponseDecodeHook", func() {
-		var i types.ResponseDecodeHook
-		o := Zone{}
-		Expect(&o).To(ImplementInterface(&i))
-	})
 	It("implements the interface types.RequestFilterHook", func() {
 		var i types.RequestFilterHook
 		o := Zone{}

--- a/pkg/apis/clouddns/v1/zone_genclient.go
+++ b/pkg/apis/clouddns/v1/zone_genclient.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -16,12 +15,6 @@ import (
 func (z *Zone) EndpointURL(ctx context.Context) (*url.URL, error) {
 	u, err := url.ParseRequestURI("/api/clouddns/v1/zone.json/")
 	return u, err
-}
-
-func (z *Zone) DecodeAPIResponse(ctx context.Context, data io.Reader) error {
-	// Declare a custom decoder which allows unknown fields - the Zone struct is not modelling all the fields
-	d := json.NewDecoder(data)
-	return d.Decode(z)
 }
 
 func (z *Zone) FilterAPIRequest(ctx context.Context, req *http.Request) (*http.Request, error) {

--- a/pkg/apis/clouddns/v1/zone_types.go
+++ b/pkg/apis/clouddns/v1/zone_types.go
@@ -19,7 +19,7 @@ type DNSServer struct {
 	Alias string `json:"alias"`
 }
 
-// anxcloud:object:hooks=ResponseDecodeHook,RequestFilterHook,RequestBodyHook,ResponseFilterHook,PaginationSupportHook
+// anxcloud:object:hooks=RequestFilterHook,RequestBodyHook,ResponseFilterHook,PaginationSupportHook
 
 type Zone struct {
 	// Zone name


### PR DESCRIPTION
### Description

We configured the JSON decoder in use by the generic client to
`DisallowUnknownFields` before, because encoding/json does not know
about required fields, resulting in every json object being decodable
into every Go struct, but we want to make sure the response is actually
the type we expect.

Turns out this is only really needed for checking which style of
pagination response we got, not for objects and we already have
different code paths for decoding pagination responses and objects. This
commit allows unknown fields for objects.

We previously had a test case for a valid pagination response with
invalid objects in it. We did not see that in real life (as far as we
remember), so we removed that test case - hoping the Engine does not
throw such responses at us.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

* [SYSENG-753](https://ats.anexia-it.com/browse/SYSENG-753), not fully resolving the issue but doing the more urgent part of it

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
