### PR TITLE
vsphere integration tests: template name prefix

### DIFF
--- a/pkg/vsphere/integration_test.go
+++ b/pkg/vsphere/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -34,13 +35,13 @@ const (
 	locationID = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
 	vlanID     = "02f39d20ca0f4adfb5032f88dbc26c39"
 
-	templateType  = "templates"
-	templateName  = "Flatcar Linux Stable"
-	cpus          = 2
-	sockets       = 1
-	changedMemory = 4096
-	memory        = 2048
-	disk          = 10
+	templateType       = "templates"
+	templateNamePrefix = "Flatcar Linux"
+	cpus               = 2
+	sockets            = 1
+	changedMemory      = 4096
+	memory             = 2048
+	disk               = 10
 )
 
 func BeBuiltFromTemplate(id string) gomegaTypes.GomegaMatcher {
@@ -166,7 +167,7 @@ var _ = Describe("vsphere API client", Ordered, func() {
 
 		selected := make([]templates.Template, 0, 1)
 		for _, tpl := range tpls {
-			if tpl.Name == templateName {
+			if strings.HasPrefix(tpl.Name, templateNamePrefix) {
 				selected = append(selected, tpl)
 			}
 		}


### PR DESCRIPTION
### Description

Template name changed in the Engine from `Flatcar Linux Stable` to `Flatcar Linux stable` ... use prefix `Flatcar Linux` instead.

Technically the `stable`/`Stable` is the version field of the template, just not differentiated via API - so with this change we select the highest `build` of the `Flatcar Linux` template, regardless of its version.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

* [SYSENG-866](https://ats.anexia-it.com/browse/SYSENG-866)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
