### PR TITLE
CI: update go.anx.io on pushed tags

### DIFF
--- a/.github/workflows/update-go.anx.io.yml
+++ b/.github/workflows/update-go.anx.io.yml
@@ -2,11 +2,6 @@ name: Trigger go.anx.io update
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   trigger:


### PR DESCRIPTION
### Description

The go.anx.io update workflow was only called for branches, this changes it to also trigger on pushed tags.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
