### PR TITLE
Add VLAN bindings for generic client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ e.g.
 * vsphere/provisioning - added progress identifier
 -->
 
+### Added
+* new APIs supported with generic client:
+  - core/location
+  - vlan
+
 ## [0.4.0] - 2022-01-24
 
 ### Added

--- a/pkg/api/types/errors.go
+++ b/pkg/api/types/errors.go
@@ -1,0 +1,15 @@
+package types
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrInvalidFilter is returned when the configured filters cannot be applied to a List operation.
+	ErrInvalidFilter = errors.New("invalid filters configured")
+
+	// ErrInvalidFilterCombination is returned when the configured filters cannot be combined in a single
+	// List operation. It wraps ErrInvalidFilter.
+	ErrInvalidFilterCombination = fmt.Errorf("%w: combination of filters", ErrInvalidFilter)
+)

--- a/pkg/apis/core/v1/location_e2e_test.go
+++ b/pkg/apis/core/v1/location_e2e_test.go
@@ -30,8 +30,8 @@ var _ = Describe("location E2E tests", func() {
 		Expect(loc.CountryCode).To(Equal("AT"))
 		Expect(loc.Latitude).NotTo(BeNil())
 		Expect(loc.Longitude).NotTo(BeNil())
-		Expect(*loc.Latitude).To(BeNumerically("~", 48.19300))
-		Expect(*loc.Longitude).To(BeNumerically("~", 16.35338))
+		Expect(*loc.Latitude).To(Equal("48.1930000000000"))
+		Expect(*loc.Longitude).To(Equal("16.3533800000000"))
 	}
 
 	matchesANX63 := func(loc Location) {
@@ -41,8 +41,8 @@ var _ = Describe("location E2E tests", func() {
 		Expect(loc.CountryCode).To(Equal("NL"))
 		Expect(loc.Latitude).NotTo(BeNil())
 		Expect(loc.Longitude).NotTo(BeNil())
-		Expect(*loc.Latitude).To(BeNumerically("~", 52.3702157))
-		Expect(*loc.Longitude).To(BeNumerically("~", 4.8951679))
+		Expect(*loc.Latitude).To(Equal("52.3702157000000"))
+		Expect(*loc.Longitude).To(Equal("4.8951679000000"))
 	}
 
 	DescribeTable("retrieves location with expected data",

--- a/pkg/apis/core/v1/location_e2e_test.go
+++ b/pkg/apis/core/v1/location_e2e_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+// +build integration
+
+package v1
+
+import (
+	"context"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("location E2E tests", func() {
+	var apiClient api.API
+
+	BeforeEach(func() {
+		a, err := api.NewAPI(api.WithClientOptions(client.AuthFromEnv(false)))
+		Expect(err).ToNot(HaveOccurred())
+		apiClient = a
+	})
+
+	matchesANX04 := func(loc Location) {
+		Expect(loc.Identifier).To(Equal("52b5f6b2fd3a4a7eaaedf1a7c019e9ea"))
+		Expect(loc.Name).To(Equal("AT, Vienna, Datasix"))
+		Expect(loc.CityCode).To(Equal("VIE"))
+		Expect(loc.CountryCode).To(Equal("AT"))
+		Expect(loc.Latitude).NotTo(BeNil())
+		Expect(loc.Longitude).NotTo(BeNil())
+		Expect(*loc.Latitude).To(BeNumerically("~", 48.19300))
+		Expect(*loc.Longitude).To(BeNumerically("~", 16.35338))
+	}
+
+	matchesANX63 := func(loc Location) {
+		Expect(loc.Identifier).To(Equal("c2e3d5caa3604cbf9ae49471fb027010"))
+		Expect(loc.Name).To(Equal("NL, Amsterdam"))
+		Expect(loc.CityCode).To(Equal("AMS"))
+		Expect(loc.CountryCode).To(Equal("NL"))
+		Expect(loc.Latitude).NotTo(BeNil())
+		Expect(loc.Longitude).NotTo(BeNil())
+		Expect(*loc.Latitude).To(BeNumerically("~", 52.3702157))
+		Expect(*loc.Longitude).To(BeNumerically("~", 4.8951679))
+	}
+
+	DescribeTable("retrieves location with expected data",
+		func(identifier string, check func(l Location)) {
+			l := Location{Identifier: identifier}
+			err := apiClient.Get(context.TODO(), &l)
+			Expect(err).NotTo(HaveOccurred())
+
+			check(l)
+		},
+		Entry("ANX04", "52b5f6b2fd3a4a7eaaedf1a7c019e9ea", matchesANX04),
+		Entry("ANX63", "c2e3d5caa3604cbf9ae49471fb027010", matchesANX63),
+	)
+
+	It("lists locations, retrieving example locations with expected data", func() {
+		var oc types.ObjectChannel
+		err := apiClient.List(context.TODO(), &Location{}, api.ObjectChannel(&oc))
+		Expect(err).ToNot(HaveOccurred())
+
+		found := make([]string, 0)
+
+		for r := range oc {
+			var loc Location
+			err := r(&loc)
+			Expect(err).NotTo(HaveOccurred())
+
+			found = append(found, loc.Code)
+
+			if loc.Code == "ANX04" {
+				matchesANX04(loc)
+			} else if loc.Code == "ANX63" {
+				matchesANX63(loc)
+			}
+		}
+
+		Expect(found).To(ContainElement("ANX04"))
+		Expect(found).To(ContainElement("ANX63"))
+	})
+})

--- a/pkg/apis/core/v1/location_genclient.go
+++ b/pkg/apis/core/v1/location_genclient.go
@@ -1,0 +1,61 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+func (l *Location) EndpointURL(ctx context.Context) (*url.URL, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Locations can only be retrieved via the public engine, nothing else
+	if op != types.OperationGet && op != types.OperationList {
+		return nil, api.ErrOperationNotSupported
+	}
+
+	return url.Parse("/api/core/v1/location.json")
+}
+
+func (l *Location) DecodeAPIResponse(ctx context.Context, body io.Reader) error {
+	type apiLocation struct {
+		Location
+		Lat *string `json:"lat"`
+		Lon *string `json:"lon"`
+	}
+
+	loc := apiLocation{}
+	if err := json.NewDecoder(body).Decode(&loc); err != nil {
+		return err
+	}
+
+	if loc.Lat != nil {
+		lat, err := strconv.ParseFloat(*loc.Lat, 64)
+		if err != nil {
+			return fmt.Errorf("error parsing latitude: %w", err)
+		}
+
+		loc.Location.Latitude = &lat
+	}
+
+	if loc.Lon != nil {
+		lon, err := strconv.ParseFloat(*loc.Lon, 64)
+		if err != nil {
+			return fmt.Errorf("error parsing longitude: %w", err)
+		}
+
+		loc.Location.Longitude = &lon
+	}
+
+	*l = loc.Location
+	return nil
+}

--- a/pkg/apis/core/v1/location_genclient.go
+++ b/pkg/apis/core/v1/location_genclient.go
@@ -2,11 +2,7 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/url"
-	"strconv"
 
 	"go.anx.io/go-anxcloud/pkg/api"
 	"go.anx.io/go-anxcloud/pkg/api/types"
@@ -24,38 +20,4 @@ func (l *Location) EndpointURL(ctx context.Context) (*url.URL, error) {
 	}
 
 	return url.Parse("/api/core/v1/location.json")
-}
-
-func (l *Location) DecodeAPIResponse(ctx context.Context, body io.Reader) error {
-	type apiLocation struct {
-		Location
-		Lat *string `json:"lat"`
-		Lon *string `json:"lon"`
-	}
-
-	loc := apiLocation{}
-	if err := json.NewDecoder(body).Decode(&loc); err != nil {
-		return err
-	}
-
-	if loc.Lat != nil {
-		lat, err := strconv.ParseFloat(*loc.Lat, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing latitude: %w", err)
-		}
-
-		loc.Location.Latitude = &lat
-	}
-
-	if loc.Lon != nil {
-		lon, err := strconv.ParseFloat(*loc.Lon, 64)
-		if err != nil {
-			return fmt.Errorf("error parsing longitude: %w", err)
-		}
-
-		loc.Location.Longitude = &lon
-	}
-
-	*l = loc.Location
-	return nil
 }

--- a/pkg/apis/core/v1/location_test.go
+++ b/pkg/apis/core/v1/location_test.go
@@ -2,9 +2,6 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,103 +25,5 @@ var _ = Describe("Location Object", func() {
 		Entry("for Create operation", types.OperationCreate),
 		Entry("for Update operation", types.OperationUpdate),
 		Entry("for Destroy operation", types.OperationDestroy),
-	)
-
-	DescribeTable("ResponseDecodeHook",
-		// expLat and expLon are passed as string to have nil ("") and a value without needing pointers,
-		// constants of which are a pain in the ass to pass to a function
-		func(expErr error, expLatS, expLonS, bodySnippet string) {
-			var expLat *float64
-			var expLon *float64
-
-			if expLatS != "" {
-				v, err := strconv.ParseFloat(expLatS, 64)
-				if err != nil {
-					panic(err)
-				}
-
-				expLat = &v
-			}
-
-			if expLonS != "" {
-				v, err := strconv.ParseFloat(expLonS, 64)
-				if err != nil {
-					panic(err)
-				}
-
-				expLon = &v
-			}
-
-			loc := Location{}
-
-			data := []byte(
-				fmt.Sprintf(
-					`{`+
-						`"identifier":"foo",`+
-						`"name":"DE, Chemnitz, dev home office",`+
-						`"code":"ANX1337",`+
-						`"city_code":"C",`+
-						`"country":"DE",`+
-						`%s}`,
-					bodySnippet,
-				),
-			)
-			err := loc.UnmarshalJSON(data)
-
-			if expErr != nil {
-				Expect(err).To(Or(
-					MatchError(expErr),
-					BeAssignableToTypeOf(expErr),
-				))
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-
-				if expLat != nil {
-					Expect(loc.Latitude).NotTo(BeNil())
-					Expect(*loc.Latitude).To(BeNumerically("~", *expLat))
-				} else {
-					Expect(loc.Latitude).To(BeNil())
-				}
-
-				if expLon != nil {
-					Expect(loc.Longitude).NotTo(BeNil())
-					Expect(*loc.Longitude).To(BeNumerically("~", *expLon))
-				} else {
-					Expect(loc.Longitude).To(BeNil())
-				}
-			}
-		},
-		Entry("invalid json given",
-			&json.SyntaxError{}, "", "",
-			`asäldjaölskdjöalsnbf SDKGJNmäqRE`,
-		),
-		Entry("given values",
-			nil, "42", "23",
-			`"lat":"42.0000000","lon":"23.00000"`,
-		),
-		Entry("only latitude given",
-			nil, "42", "",
-			`"lat":"42.0000000","lon":null`,
-		),
-		Entry("only longitude given",
-			nil, "", "23",
-			`"lat":null,"lon":"23.00000"`,
-		),
-		Entry("none given",
-			nil, "", "",
-			`"lat":null,"lon":null`,
-		),
-		Entry("empty strings given",
-			strconv.ErrSyntax, "", "",
-			`"lat":"","lon":""`,
-		),
-		Entry("invalid string given for latitude",
-			strconv.ErrSyntax, "", "",
-			`"lat":"blurb","lon":null`,
-		),
-		Entry("invalid string given for longitude",
-			strconv.ErrSyntax, "", "",
-			`"lat":null,"lon":"blurb"`,
-		),
 	)
 })

--- a/pkg/apis/core/v1/location_test.go
+++ b/pkg/apis/core/v1/location_test.go
@@ -1,7 +1,6 @@
 package v1
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -58,7 +57,7 @@ var _ = Describe("Location Object", func() {
 
 			loc := Location{}
 
-			reader := bytes.NewBufferString(
+			data := []byte(
 				fmt.Sprintf(
 					`{`+
 						`"identifier":"foo",`+
@@ -70,7 +69,7 @@ var _ = Describe("Location Object", func() {
 					bodySnippet,
 				),
 			)
-			err := loc.DecodeAPIResponse(context.TODO(), reader)
+			err := loc.UnmarshalJSON(data)
 
 			if expErr != nil {
 				Expect(err).To(Or(

--- a/pkg/apis/core/v1/location_test.go
+++ b/pkg/apis/core/v1/location_test.go
@@ -1,0 +1,131 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+var _ = Describe("Location Object", func() {
+	var o *Location
+
+	BeforeEach(func() {
+		o = &Location{}
+	})
+
+	DescribeTable("gives ErrOperationNotSupported",
+		func(op types.Operation) {
+			_, err := o.EndpointURL(types.ContextWithOperation(context.TODO(), op))
+			Expect(err).To(MatchError(api.ErrOperationNotSupported))
+		},
+		Entry("for Create operation", types.OperationCreate),
+		Entry("for Update operation", types.OperationUpdate),
+		Entry("for Destroy operation", types.OperationDestroy),
+	)
+
+	DescribeTable("ResponseDecodeHook",
+		// expLat and expLon are passed as string to have nil ("") and a value without needing pointers,
+		// constants of which are a pain in the ass to pass to a function
+		func(expErr error, expLatS, expLonS, bodySnippet string) {
+			var expLat *float64
+			var expLon *float64
+
+			if expLatS != "" {
+				v, err := strconv.ParseFloat(expLatS, 64)
+				if err != nil {
+					panic(err)
+				}
+
+				expLat = &v
+			}
+
+			if expLonS != "" {
+				v, err := strconv.ParseFloat(expLonS, 64)
+				if err != nil {
+					panic(err)
+				}
+
+				expLon = &v
+			}
+
+			loc := Location{}
+
+			reader := bytes.NewBufferString(
+				fmt.Sprintf(
+					`{`+
+						`"identifier":"foo",`+
+						`"name":"DE, Chemnitz, dev home office",`+
+						`"code":"ANX1337",`+
+						`"city_code":"C",`+
+						`"country":"DE",`+
+						`%s}`,
+					bodySnippet,
+				),
+			)
+			err := loc.DecodeAPIResponse(context.TODO(), reader)
+
+			if expErr != nil {
+				Expect(err).To(Or(
+					MatchError(expErr),
+					BeAssignableToTypeOf(expErr),
+				))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+
+				if expLat != nil {
+					Expect(loc.Latitude).NotTo(BeNil())
+					Expect(*loc.Latitude).To(BeNumerically("~", *expLat))
+				} else {
+					Expect(loc.Latitude).To(BeNil())
+				}
+
+				if expLon != nil {
+					Expect(loc.Longitude).NotTo(BeNil())
+					Expect(*loc.Longitude).To(BeNumerically("~", *expLon))
+				} else {
+					Expect(loc.Longitude).To(BeNil())
+				}
+			}
+		},
+		Entry("invalid json given",
+			&json.SyntaxError{}, "", "",
+			`asäldjaölskdjöalsnbf SDKGJNmäqRE`,
+		),
+		Entry("given values",
+			nil, "42", "23",
+			`"lat":"42.0000000","lon":"23.00000"`,
+		),
+		Entry("only latitude given",
+			nil, "42", "",
+			`"lat":"42.0000000","lon":null`,
+		),
+		Entry("only longitude given",
+			nil, "", "23",
+			`"lat":null,"lon":"23.00000"`,
+		),
+		Entry("none given",
+			nil, "", "",
+			`"lat":null,"lon":null`,
+		),
+		Entry("empty strings given",
+			strconv.ErrSyntax, "", "",
+			`"lat":"","lon":""`,
+		),
+		Entry("invalid string given for latitude",
+			strconv.ErrSyntax, "", "",
+			`"lat":"blurb","lon":null`,
+		),
+		Entry("invalid string given for longitude",
+			strconv.ErrSyntax, "", "",
+			`"lat":null,"lon":"blurb"`,
+		),
+	)
+})

--- a/pkg/apis/core/v1/location_types.go
+++ b/pkg/apis/core/v1/location_types.go
@@ -1,134 +1,14 @@
 package v1
 
-import (
-	"encoding/json"
-	"fmt"
-	"reflect"
-	"strconv"
-)
-
 // anxcloud:object
 
 // Location describes a Anexia site where resources can be deployed.
 type Location struct {
-	Identifier  string `json:"identifier" anxcloud:"identifier"`
-	Code        string `json:"code"`
-	Name        string `json:"name"`
-	CountryCode string `json:"country"`
-	CityCode    string `json:"city_code"`
-
-	Latitude  *float64 `json:"lat"`
-	Longitude *float64 `json:"lon"`
-}
-
-// UnmarshalJSON handles latitude and longitude given as strings instead of floats by the API.
-func (l *Location) UnmarshalJSON(body []byte) error {
-	loc := reflect.New(generateAPIType())
-	if err := json.Unmarshal(body, loc.Interface()); err != nil {
-		return err
-	}
-
-	return l.fromAPIType(loc)
-}
-
-// MarshalJSON handles latitude and longitude being expected as strings instead of floats by the API.
-func (l Location) MarshalJSON() ([]byte, error) {
-	return json.Marshal(l.asAPIType())
-}
-
-// generateAPIType generates a new struct type as the API wants the JSON to look, matching the Location type
-// but instead of having *float64 types on Latitude and Longitude, the API wants *string.
-// We cannot simply make a "apiLocation" struct with Location embedded because we then run into a stack
-// overflow - as this function is called to unmarshal the embedded type. Instead we build the struct
-// type with reflection. This gives this complicated code here and below, but we only have to add new fields
-// to a single struct, making it way less error prone.
-func generateAPIType() reflect.Type {
-	originalType := reflect.TypeOf(Location{})
-	fields := make([]reflect.StructField, originalType.NumField())
-
-	for i := range fields {
-		field := originalType.Field(i)
-		fields[i] = field
-
-		// for the fields "Latitude" and "Longitude" we change the type to *string
-		if field.Name == "Latitude" || field.Name == "Longitude" {
-			fields[i].Type = reflect.PtrTo(
-				reflect.TypeOf(""),
-			)
-		}
-	}
-
-	return reflect.StructOf(fields)
-}
-
-// fromAPIType fills the received Location from the given API type (see generateAPIType above).
-func (l *Location) fromAPIType(apiLocation reflect.Value) error {
-	apiLocationType := apiLocation.Type().Elem()
-
-	// copy the fields over, parsing Latitude and Longitude from string to float64
-	destValue := reflect.ValueOf(l)
-
-	for i := 0; i < apiLocation.Elem().NumField(); i++ {
-		field := apiLocationType.Field(i)
-		srcField := apiLocation.Elem().Field(i)
-		destField := destValue.Elem().Field(i)
-
-		if field.Name == "Latitude" || field.Name == "Longitude" {
-			if srcField.IsNil() {
-				nilptr := reflect.Zero(
-					reflect.PtrTo(
-						reflect.TypeOf(float64(42)),
-					),
-				)
-				destField.Set(nilptr)
-			} else {
-				f, err := strconv.ParseFloat(srcField.Elem().Interface().(string), 64)
-				if err != nil {
-					return fmt.Errorf("error parsing %v: %w", field.Name, err)
-				}
-
-				destField.Set(reflect.ValueOf(&f))
-
-			}
-		} else {
-			destField.Set(srcField)
-		}
-	}
-
-	return nil
-}
-
-// asAPIType creates a new instance of the struct expected by the API (see generateAPIType above) and fills
-// it with data from the received Location.
-func (l Location) asAPIType() interface{} {
-	apiLocationType := generateAPIType()
-	apiLocation := reflect.New(apiLocationType)
-
-	// copy the fields over, formatting  Latitude and Longitude from float64 to string
-	srcValue := reflect.ValueOf(l)
-
-	for i := 0; i < apiLocation.Elem().NumField(); i++ {
-		field := apiLocationType.Field(i)
-		srcField := srcValue.Field(i)
-		destField := apiLocation.Elem().Field(i)
-
-		if field.Name == "Latitude" || field.Name == "Longitude" {
-			if srcField.IsNil() {
-				nilptr := reflect.Zero(
-					reflect.PtrTo(
-						reflect.TypeOf(""),
-					),
-				)
-				destField.Set(nilptr)
-			} else {
-				s := strconv.FormatFloat(srcField.Elem().Interface().(float64), 'f', -1, 64)
-				destField.Set(reflect.ValueOf(&s))
-
-			}
-		} else {
-			destField.Set(srcField)
-		}
-	}
-
-	return apiLocation.Elem().Interface()
+	Identifier  string  `json:"identifier" anxcloud:"identifier"`
+	Code        string  `json:"code"`
+	Name        string  `json:"name"`
+	CountryCode string  `json:"country"`
+	CityCode    string  `json:"city_code"`
+	Latitude    *string `json:"lat"`
+	Longitude   *string `json:"lon"`
 }

--- a/pkg/apis/core/v1/location_types.go
+++ b/pkg/apis/core/v1/location_types.go
@@ -1,14 +1,134 @@
 package v1
 
-// anxcloud:object:hooks=ResponseDecodeHook
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
 
-// Location describe a Anexia site where resources can be deployed.
+// anxcloud:object
+
+// Location describes a Anexia site where resources can be deployed.
 type Location struct {
-	Identifier  string   `json:"identifier" anxcloud:"identifier"`
-	Code        string   `json:"code"`
-	Name        string   `json:"name"`
-	CountryCode string   `json:"country"`
-	CityCode    string   `json:"city_code"`
-	Latitude    *float64 `json:"lat"`
-	Longitude   *float64 `json:"lon"`
+	Identifier  string `json:"identifier" anxcloud:"identifier"`
+	Code        string `json:"code"`
+	Name        string `json:"name"`
+	CountryCode string `json:"country"`
+	CityCode    string `json:"city_code"`
+
+	Latitude  *float64 `json:"lat"`
+	Longitude *float64 `json:"lon"`
+}
+
+// UnmarshalJSON handles latitude and longitude given as strings instead of floats by the API.
+func (l *Location) UnmarshalJSON(body []byte) error {
+	loc := reflect.New(generateAPIType())
+	if err := json.Unmarshal(body, loc.Interface()); err != nil {
+		return err
+	}
+
+	return l.fromAPIType(loc)
+}
+
+// MarshalJSON handles latitude and longitude being expected as strings instead of floats by the API.
+func (l Location) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.asAPIType())
+}
+
+// generateAPIType generates a new struct type as the API wants the JSON to look, matching the Location type
+// but instead of having *float64 types on Latitude and Longitude, the API wants *string.
+// We cannot simply make a "apiLocation" struct with Location embedded because we then run into a stack
+// overflow - as this function is called to unmarshal the embedded type. Instead we build the struct
+// type with reflection. This gives this complicated code here and below, but we only have to add new fields
+// to a single struct, making it way less error prone.
+func generateAPIType() reflect.Type {
+	originalType := reflect.TypeOf(Location{})
+	fields := make([]reflect.StructField, originalType.NumField())
+
+	for i := range fields {
+		field := originalType.Field(i)
+		fields[i] = field
+
+		// for the fields "Latitude" and "Longitude" we change the type to *string
+		if field.Name == "Latitude" || field.Name == "Longitude" {
+			fields[i].Type = reflect.PtrTo(
+				reflect.TypeOf(""),
+			)
+		}
+	}
+
+	return reflect.StructOf(fields)
+}
+
+// fromAPIType fills the received Location from the given API type (see generateAPIType above).
+func (l *Location) fromAPIType(apiLocation reflect.Value) error {
+	apiLocationType := apiLocation.Type().Elem()
+
+	// copy the fields over, parsing Latitude and Longitude from string to float64
+	destValue := reflect.ValueOf(l)
+
+	for i := 0; i < apiLocation.Elem().NumField(); i++ {
+		field := apiLocationType.Field(i)
+		srcField := apiLocation.Elem().Field(i)
+		destField := destValue.Elem().Field(i)
+
+		if field.Name == "Latitude" || field.Name == "Longitude" {
+			if srcField.IsNil() {
+				nilptr := reflect.Zero(
+					reflect.PtrTo(
+						reflect.TypeOf(float64(42)),
+					),
+				)
+				destField.Set(nilptr)
+			} else {
+				f, err := strconv.ParseFloat(srcField.Elem().Interface().(string), 64)
+				if err != nil {
+					return fmt.Errorf("error parsing %v: %w", field.Name, err)
+				}
+
+				destField.Set(reflect.ValueOf(&f))
+
+			}
+		} else {
+			destField.Set(srcField)
+		}
+	}
+
+	return nil
+}
+
+// asAPIType creates a new instance of the struct expected by the API (see generateAPIType above) and fills
+// it with data from the received Location.
+func (l Location) asAPIType() interface{} {
+	apiLocationType := generateAPIType()
+	apiLocation := reflect.New(apiLocationType)
+
+	// copy the fields over, formatting  Latitude and Longitude from float64 to string
+	srcValue := reflect.ValueOf(l)
+
+	for i := 0; i < apiLocation.Elem().NumField(); i++ {
+		field := apiLocationType.Field(i)
+		srcField := srcValue.Field(i)
+		destField := apiLocation.Elem().Field(i)
+
+		if field.Name == "Latitude" || field.Name == "Longitude" {
+			if srcField.IsNil() {
+				nilptr := reflect.Zero(
+					reflect.PtrTo(
+						reflect.TypeOf(""),
+					),
+				)
+				destField.Set(nilptr)
+			} else {
+				s := strconv.FormatFloat(srcField.Elem().Interface().(float64), 'f', -1, 64)
+				destField.Set(reflect.ValueOf(&s))
+
+			}
+		} else {
+			destField.Set(srcField)
+		}
+	}
+
+	return apiLocation.Elem().Interface()
 }

--- a/pkg/apis/core/v1/location_types.go
+++ b/pkg/apis/core/v1/location_types.go
@@ -1,0 +1,14 @@
+package v1
+
+// anxcloud:object:hooks=ResponseDecodeHook
+
+// Location describe a Anexia site where resources can be deployed.
+type Location struct {
+	Identifier  string   `json:"identifier" anxcloud:"identifier"`
+	Code        string   `json:"code"`
+	Name        string   `json:"name"`
+	CountryCode string   `json:"country"`
+	CityCode    string   `json:"city_code"`
+	Latitude    *float64 `json:"lat"`
+	Longitude   *float64 `json:"lon"`
+}

--- a/pkg/apis/core/v1/xxgenerated_object_test.go
+++ b/pkg/apis/core/v1/xxgenerated_object_test.go
@@ -7,6 +7,22 @@ import (
 	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
+var _ = Describe("Object Location", func() {
+	o := Location{}
+
+	ifaces := make([]interface{}, 0, 2)
+	{
+		var i types.Object
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.ResponseDecodeHook
+		ifaces = append(ifaces, &i)
+	}
+
+	testutils.ObjectTests(&o, ifaces...)
+})
+
 var _ = Describe("Object Info", func() {
 	o := Info{}
 

--- a/pkg/apis/core/v1/xxgenerated_object_test.go
+++ b/pkg/apis/core/v1/xxgenerated_object_test.go
@@ -10,13 +10,9 @@ import (
 var _ = Describe("Object Location", func() {
 	o := Location{}
 
-	ifaces := make([]interface{}, 0, 2)
+	ifaces := make([]interface{}, 0, 1)
 	{
 		var i types.Object
-		ifaces = append(ifaces, &i)
-	}
-	{
-		var i types.ResponseDecodeHook
 		ifaces = append(ifaces, &i)
 	}
 

--- a/pkg/apis/vlan/v1/genclient.go
+++ b/pkg/apis/vlan/v1/genclient.go
@@ -1,0 +1,66 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	apiTypes "go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+func (v *VLAN) EndpointURL(ctx context.Context) (*url.URL, error) {
+	op, err := apiTypes.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == apiTypes.OperationList {
+		query := url.Values{}
+
+		if v.Status != StatusInvalid {
+			query.Add("status", string(v.Status))
+		}
+
+		if l := len(v.Locations); l == 1 {
+			query.Add("location", v.Locations[0].Identifier)
+		} else if l > 1 {
+			return nil, ErrFilterMultipleLocations
+		}
+
+		// we don't catch the error from url.Parse because this URL is hardcoded-valid.
+		u, _ := url.Parse("/api/vlan/v1/vlan.json/filtered")
+		u.RawQuery = query.Encode()
+
+		return u, nil
+	}
+
+	return url.Parse("/api/vlan/v1/vlan.json")
+}
+
+func (v *VLAN) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
+	op, err := apiTypes.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Creating a VLAN is done with a single location only, despite the API returning an array.
+	if op == apiTypes.OperationCreate {
+		if len(v.Locations) != 1 {
+			return nil, fmt.Errorf("%w: %v locations given", ErrLocationCount, len(v.Locations))
+		}
+
+		data := struct {
+			VLAN
+			Location string `json:"location"`
+		}{
+			VLAN:     *v,
+			Location: v.Locations[0].Identifier,
+		}
+
+		data.VLAN.Locations = nil
+
+		return data, nil
+	}
+
+	return v, nil
+}

--- a/pkg/apis/vlan/v1/types.go
+++ b/pkg/apis/vlan/v1/types.go
@@ -1,0 +1,53 @@
+package v1
+
+import (
+	"errors"
+	"fmt"
+
+	apiTypes "go.anx.io/go-anxcloud/pkg/api/types"
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+)
+
+// Status describe the deployment status of a VLAN.
+type Status string
+
+const (
+	// StatusInvalid is a client-internal, invalid status which is only used to check if a status is set for filtering.
+	StatusInvalid Status = ""
+
+	// StatusActive means the VLAN is fully deployed and ready to be used.
+	StatusActive Status = "Active"
+
+	// StatusPending is set when a VLAN is newly created and not yet ready to be used.
+	StatusPending Status = "Pending"
+
+	// StatusMarkedForDeletion means the VLAN was requested to be deleted, which is still pending.
+	StatusMarkedForDeletion Status = "Marked for deletion"
+)
+
+var (
+	// ErrFilterMultipleLocations is returned when trying to List VLANs with multiple locations configured
+	// for filtering - which is not implemented.
+	ErrFilterMultipleLocations = fmt.Errorf("%w: cannot filter on multiple locations", apiTypes.ErrInvalidFilter)
+
+	// ErrLocationCount is returned when trying to create a VLAN with no or more than one location.
+	ErrLocationCount = errors.New("VLANs have to be created with exactly one Location")
+)
+
+// anxcloud:object:hooks=RequestBodyHook
+
+// VLAN describes a virtual network IP prefixes, virtual machines (if VMProvisioning is true) and
+// alike can be deployed into.
+type VLAN struct {
+	Identifier          string `json:"identifier,omitempty" anxcloud:"identifier"`
+	Name                string `json:"name,omitempty"`
+	DescriptionCustomer string `json:"description_customer,omitempty"`
+	RoleText            string `json:"role_text,omitempty"`
+	Status              Status `json:"status,omitempty" anxcloud:"filterable"`
+	VMProvisioning      bool   `json:"vm_provisioning"`
+
+	// The API returns an array of locations, but there is no way to configure more than one location via the API.
+	// Additionally, not even the one location can be updated via API.
+	// When creating a VLAN pass a single Location object, only the Identifier needs to be set on it.
+	Locations []corev1.Location `json:"locations,omitempty" anxcloud:"filterable"`
+}

--- a/pkg/apis/vlan/v1/vlan_e2e_mock_test.go
+++ b/pkg/apis/vlan/v1/vlan_e2e_mock_test.go
@@ -1,0 +1,201 @@
+//go:build !integration
+// +build !integration
+
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/client"
+
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/ghttp"
+)
+
+const (
+	mockVLANIdentifier = "foobarbaz4223691337"
+
+	waitTimeout  = 30 * time.Millisecond
+	retryTimeout = 10 * time.Millisecond
+)
+
+var (
+	mockServer *Server
+
+	// Engine takes some time to assign a name, emulate with this
+	mockGetAssigned = false
+
+	// Engine takes some time to have a new VLAN active, emulate with this
+	mockGetActive = false
+
+	// After destroying, the Engine needs some time to actually delete it - emulate with this
+	mockGetDeleting = false
+
+	// This is set to true to return a 404 response when retrieving our test VLAN
+	mockGetDeleted = false
+)
+
+func e2eApiClient() (api.API, error) {
+	if mockServer == nil {
+		mockServer = NewServer()
+	}
+
+	return api.NewAPI(
+		api.WithClientOptions(
+			client.BaseURL(mockServer.URL()),
+			client.IgnoreMissingToken(),
+		),
+	)
+}
+
+func mockVLANResponseBody(desc string, vmProvisioning bool) map[string]interface{} {
+	name := "newVLAN-422369"
+	status := "Pending"
+
+	if mockGetAssigned {
+		name = "VLAN1000"
+	}
+
+	if mockGetDeleting {
+		status = "Marked for deletion"
+	} else if mockGetActive {
+		status = "Active"
+	}
+
+	return map[string]interface{}{
+		"identifier":           mockVLANIdentifier,
+		"name":                 name,
+		"description_customer": desc,
+		"description_internal": "",
+		"role_text":            "SCND generated",
+		"status":               status,
+		"locations": []map[string]interface{}{
+			{
+				"identifier": locationIdentifier,
+				"name":       "ANX04",
+			},
+		},
+		"vm_provisioning": vmProvisioning,
+	}
+}
+
+func prepareCreate(desc string) {
+	mockServer.AppendHandlers(CombineHandlers(
+		VerifyRequest("POST", "/api/vlan/v1/vlan.json"),
+		VerifyJSONRepresenting(map[string]interface{}{
+			"description_customer": desc,
+			"vm_provisioning":      false,
+			"location":             locationIdentifier,
+		}),
+		RespondWithJSONEncoded(200, map[string]interface{}{
+			"name":                 "newVLAN-422369",
+			"identifier":           mockVLANIdentifier,
+			"description_customer": desc,
+			"vm_provisioning":      false,
+			"locations": []map[string]interface{}{
+				{
+					"identifier": locationIdentifier,
+					"name":       "ANX04",
+				},
+			},
+		}),
+	))
+}
+
+func prepareGet(desc string, vmProvisioning bool) {
+	var response http.HandlerFunc
+
+	if mockGetDeleted {
+		response = RespondWith(404, ``)
+	} else {
+		body := mockVLANResponseBody(desc, vmProvisioning)
+		mockGetAssigned = true // after first request it's going to be assigned
+		response = RespondWithJSONEncoded(200, body)
+	}
+
+	mockServer.AppendHandlers(CombineHandlers(
+		VerifyRequest("GET", "/api/vlan/v1/vlan.json/"+mockVLANIdentifier),
+		response,
+	))
+}
+
+func prepareList(desc string, vmProvisioning bool) {
+	mockVLANs := []map[string]interface{}{
+		{"identifier": "foo", "name": "VLAN1337", "description_customer": "black lives matter", "vm_provisioning": true},
+		{"identifier": "bar", "name": "VLAN42", "description_customer": "trans rights are human rights", "vm_provisioning": false},
+		{"identifier": "blarz", "name": "VLAN23", "description_customer": "more good strings accepted via PR", "vm_provisioning": true},
+		{"identifier": "aölskdjasd", "name": "VLAN3324", "description_customer": "aöäslkdjlsdkgjh.lfdknhdfg", "vm_provisioning": false},
+		{"identifier": "IShouldUsePwgen", "name": "VLAN3325", "description_customer": "I really should use pwgen for this.", "vm_provisioning": true},
+		{"identifier": "6 more to go", "name": "VLAN3326", "description_customer": "I need at least two pages, having our mock one on the second page to test if its iterating correctly", "vm_provisioning": false},
+		{"identifier": "5 more to go", "name": "VLAN3327", "description_customer": "booooooring", "vm_provisioning": true},
+		{"identifier": "4 more to go", "name": "VLAN3328", "description_customer": "hey reviewer, are you reading this?", "vm_provisioning": false},
+		{"identifier": "3 more to go", "name": "VLAN3329", "description_customer": "because, if you do, I hope you are less bored", "vm_provisioning": true},
+		{"identifier": "2 more to go", "name": "VLAN3330", "description_customer": "google: how to have fun mocking things", "vm_provisioning": false},
+		{"identifier": "1 more to go", "name": "VLAN3331", "description_customer": "This is the last random one!", "vm_provisioning": true},
+		mockVLANResponseBody(desc, vmProvisioning),
+	}
+
+	pages := [][]map[string]interface{}{
+		mockVLANs[0:10],
+		mockVLANs[10:],
+		{},
+	}
+
+	Expect(pages[0]).To(HaveLen(10))
+	Expect(pages[1]).To(HaveLen(2))
+	Expect(pages[len(pages)-1]).To(HaveLen(0))
+
+	for i, data := range pages {
+		mockServer.AppendHandlers(CombineHandlers(
+			VerifyRequest("GET", "/api/vlan/v1/vlan.json/filtered", fmt.Sprintf("page=%v&limit=10", i+1)),
+			RespondWithJSONEncoded(200, map[string]interface{}{
+				"page":        i + 1,
+				"total_pages": len(pages),
+				"total_items": len(mockVLANs),
+				"limit":       len(data),
+				"data":        data,
+			}),
+		))
+	}
+}
+
+func prepareUpdate(desc string, vmProvisioning bool) {
+	mockServer.AppendHandlers(CombineHandlers(
+		VerifyRequest("PUT", "/api/vlan/v1/vlan.json/"+mockVLANIdentifier),
+		VerifyJSONRepresenting(map[string]interface{}{
+			"identifier":           mockVLANIdentifier,
+			"description_customer": desc,
+			"vm_provisioning":      vmProvisioning,
+		}),
+		RespondWithJSONEncoded(200, mockVLANResponseBody(desc, vmProvisioning)),
+	))
+}
+
+func prepareDelete() {
+	mockServer.AppendHandlers(CombineHandlers(
+		VerifyRequest("DELETE", "/api/vlan/v1/vlan.json/"+mockVLANIdentifier),
+		RespondWithJSONEncoded(200, map[string]interface{}{
+			"identifier":           nil,
+			"name":                 nil,
+			"description_customer": nil,
+		}),
+	))
+}
+
+func prepareEventuallyActive(desc string, vmProvisioning bool) {
+	prepareGet(desc, vmProvisioning)
+	mockGetActive = true // Active on second request
+}
+
+func prepareEventuallyDeleted(desc string, vmProvisioning bool) {
+	prepareGet(desc, vmProvisioning)
+	mockGetDeleted = true // Active on second request
+}
+
+func prepareDeleting() {
+	mockGetDeleting = true
+	prepareGet("", true) // values not important anymore
+}

--- a/pkg/apis/vlan/v1/vlan_e2e_prod_test.go
+++ b/pkg/apis/vlan/v1/vlan_e2e_prod_test.go
@@ -1,0 +1,37 @@
+//go:build integration
+// +build integration
+
+package v1
+
+import (
+	"time"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/client"
+)
+
+const (
+	waitTimeout  = 5 * time.Minute
+	retryTimeout = 15 * time.Second
+)
+
+func e2eApiClient() (api.API, error) {
+	return api.NewAPI(api.WithClientOptions(client.AuthFromEnv(false)))
+}
+
+// below are the functions for setting up the mock, empty for the prod E2E version
+func prepareCreate(desc string) {}
+
+func prepareGet(desc string, vmProvisioning bool) {}
+
+func prepareList(desc string, vmProvisioning bool) {}
+
+func prepareUpdate(desc string, vmProvisioning bool) {}
+
+func prepareDelete() {}
+
+func prepareEventuallyActive(desc string, vmProvisioning bool) {}
+
+func prepareEventuallyDeleted(desc string, vmProvisioning bool) {}
+
+func prepareDeleting() {}

--- a/pkg/apis/vlan/v1/vlan_e2e_test.go
+++ b/pkg/apis/vlan/v1/vlan_e2e_test.go
@@ -1,0 +1,163 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+
+	testutils "go.anx.io/go-anxcloud/pkg/utils/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+const locationIdentifier = "52b5f6b2fd3a4a7eaaedf1a7c019e9ea"
+
+var _ = Describe("VLAN E2E tests", func() {
+	var apiClient api.API
+
+	BeforeEach(func() {
+		a, err := e2eApiClient()
+		Expect(err).ToNot(HaveOccurred())
+		apiClient = a
+
+	})
+
+	Context("with a VLAN created for testing", Ordered, func() {
+		var identifier string
+		var desc string
+
+		deleted := false
+
+		BeforeAll(func() {
+			desc = "go-anxcloud test " + testutils.RandomHostname()
+			prepareCreate(desc)
+
+			vlan := VLAN{
+				DescriptionCustomer: desc,
+				Locations:           []corev1.Location{{Identifier: locationIdentifier}},
+			}
+			err := apiClient.Create(context.TODO(), &vlan)
+			Expect(err).NotTo(HaveOccurred())
+
+			identifier = vlan.Identifier
+
+			DeferCleanup(func() {
+				if !deleted {
+					err := apiClient.Destroy(context.TODO(), &VLAN{Identifier: identifier})
+					if err != nil {
+						Fail(fmt.Sprintf("Error destroying VLAN %q created for testing: %v", identifier, err))
+					}
+				}
+			})
+		})
+
+		It("should retrieve the VLAN", func() {
+			prepareGet(desc, false)
+
+			vlan := VLAN{Identifier: identifier}
+			err := apiClient.Get(context.TODO(), &vlan)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vlan.DescriptionCustomer).To(Equal(desc))
+		})
+
+		It("should list resource using generic API client", func() {
+			prepareList(desc, false)
+
+			var oc types.ObjectChannel
+			err := apiClient.List(context.TODO(), &VLAN{}, api.ObjectChannel(&oc))
+			Expect(err).ToNot(HaveOccurred())
+
+			found := false
+			for r := range oc {
+				vlan := VLAN{}
+				err := r(&vlan)
+				Expect(err).NotTo(HaveOccurred())
+
+				if vlan.Identifier == identifier {
+					found = true
+					Expect(vlan.DescriptionCustomer).To(Equal(desc))
+				}
+			}
+
+			Expect(found).To(BeTrue())
+		})
+
+		It("eventually has StatusActive", func() {
+			Eventually(func(g Gomega) {
+				prepareEventuallyActive(desc, false)
+
+				vlan := VLAN{Identifier: identifier}
+				err := apiClient.Get(context.TODO(), &vlan)
+
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(vlan.Status).To(Equal(StatusActive))
+			}, waitTimeout, retryTimeout).Should(Succeed())
+		})
+
+		It("updates to VM provisioning enabled", func() {
+			prepareUpdate(desc, true)
+
+			vlan := VLAN{
+				Identifier:          identifier,
+				DescriptionCustomer: desc,
+				VMProvisioning:      true,
+			}
+			err := apiClient.Update(context.TODO(), &vlan)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("eventually shows VM provisioning as enabled", func() {
+			Eventually(func(g Gomega) {
+				prepareGet(desc, true)
+
+				vlan := VLAN{Identifier: identifier}
+				err := apiClient.Get(context.TODO(), &vlan)
+
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(vlan.VMProvisioning).To(BeTrue())
+			}, waitTimeout, retryTimeout).Should(Succeed())
+		})
+
+		It("should destroy the VLAN", func() {
+			prepareDelete()
+
+			err := apiClient.Destroy(context.TODO(), &VLAN{Identifier: identifier})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("has StatusMarkedForDeletion", func() {
+			prepareDeleting()
+
+			vlan := VLAN{Identifier: identifier}
+			err := apiClient.Get(context.TODO(), &vlan)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vlan.Status).To(Equal(StatusMarkedForDeletion))
+		})
+
+		It("eventually is gone", func() {
+			Eventually(func(g Gomega) {
+				prepareEventuallyDeleted(desc, true)
+
+				vlan := VLAN{Identifier: identifier}
+				err := apiClient.Get(context.TODO(), &vlan)
+				g.Expect(err).To(HaveOccurred())
+
+				he := api.HTTPError{}
+				ok := errors.As(err, &he)
+				g.Expect(ok).To(BeTrue())
+
+				g.Expect(he.StatusCode()).To(Equal(404))
+			}, waitTimeout, retryTimeout).Should(Succeed())
+
+			deleted = true
+		})
+	})
+})

--- a/pkg/apis/vlan/v1/vlan_test.go
+++ b/pkg/apis/vlan/v1/vlan_test.go
@@ -1,0 +1,132 @@
+package v1
+
+import (
+	"context"
+	"net/url"
+	"reflect"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+)
+
+var _ = Describe("VLAN Object", func() {
+	DescribeTable("EndpointURL",
+		func(status Status, locations []corev1.Location, expectedQuery url.Values, expectedErrors ...error) {
+			ctx := types.ContextWithOperation(context.TODO(), types.OperationList)
+
+			o := VLAN{
+				Status:    status,
+				Locations: locations,
+			}
+
+			url, err := o.EndpointURL(ctx)
+
+			if len(expectedErrors) > 0 {
+				Expect(err).To(HaveOccurred())
+
+				for _, e := range expectedErrors {
+					Expect(err).To(MatchError(e))
+				}
+			} else {
+				query := url.Query()
+				Expect(query).To(BeEquivalentTo(expectedQuery))
+			}
+		},
+		Entry(
+			"when no filters are set",
+			StatusInvalid,
+			nil,
+			url.Values{},
+		),
+		Entry(
+			"when Status is set to Active",
+			StatusActive,
+			nil,
+			url.Values{
+				"status": []string{"Active"},
+			},
+		),
+		Entry(
+			"when one Location is set",
+			StatusInvalid,
+			[]corev1.Location{{Identifier: "foo"}},
+			url.Values{
+				"location": []string{"foo"},
+			},
+		),
+		Entry(
+			"when Status and one Location is set",
+			StatusActive,
+			[]corev1.Location{
+				{Identifier: "foo"},
+			},
+			url.Values{
+				"status":   []string{"Active"},
+				"location": []string{"foo"},
+			},
+		),
+		Entry(
+			"when two Location are set",
+			StatusInvalid,
+			[]corev1.Location{
+				{Identifier: "foo"},
+				{Identifier: "bar"},
+			},
+			nil,
+			types.ErrInvalidFilter,
+			ErrFilterMultipleLocations,
+		),
+	)
+
+	DescribeTable("FilterAPIRequest",
+		func(locations []corev1.Location, expErr error) {
+			ctx := types.ContextWithOperation(context.TODO(), types.OperationCreate)
+
+			vlan := VLAN{Locations: locations}
+
+			data, err := vlan.FilterAPIRequestBody(ctx)
+
+			if expErr != nil {
+				Expect(err).To(MatchError(expErr))
+				Expect(data).To(BeNil())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(data).NotTo(BeNil())
+
+				rval := reflect.ValueOf(data)
+				locationIdentifier := rval.FieldByName("Location").Interface().(string)
+
+				Expect(locationIdentifier).To(Equal(locations[0].Identifier))
+			}
+		},
+		Entry(
+			"errors without any location",
+			[]corev1.Location{},
+			ErrLocationCount,
+		),
+		Entry(
+			"errors with two locations",
+			[]corev1.Location{
+				{Identifier: "foo"},
+				{Identifier: "bar"},
+			},
+			ErrLocationCount,
+		),
+		Entry(
+			"succeeds with a single location",
+			[]corev1.Location{
+				{Identifier: "foo"},
+			},
+			nil,
+		),
+	)
+})
+
+func TestVLAN(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "test suite for VLAN API definition")
+}

--- a/pkg/apis/vlan/v1/xxgenerated_object_test.go
+++ b/pkg/apis/vlan/v1/xxgenerated_object_test.go
@@ -1,0 +1,24 @@
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	testutils "go.anx.io/go-anxcloud/pkg/utils/test"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+var _ = Describe("Object VLAN", func() {
+	o := VLAN{}
+
+	ifaces := make([]interface{}, 0, 2)
+	{
+		var i types.Object
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.RequestBodyHook
+		ifaces = append(ifaces, &i)
+	}
+
+	testutils.ObjectTests(&o, ifaces...)
+})

--- a/pkg/utils/test/object.go
+++ b/pkg/utils/test/object.go
@@ -28,12 +28,13 @@ func ObjectTests(o types.Object, hooks ...interface{}) {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	})
 
-	for _, hook := range hooks {
-		name := reflect.TypeOf(hook).Elem().Name()
+	for _, hookPtr := range hooks {
+		hook := reflect.TypeOf(hookPtr).Elem()
+		name := hook.Name()
 
 		ginkgo.Context(fmt.Sprintf("implementing %v", name), func() {
 			ginkgo.It("actually implements the interface", func() {
-				implementsHook := reflect.TypeOf(o).Implements(reflect.TypeOf(hook).Elem())
+				implementsHook := reflect.TypeOf(o).Implements(hook)
 				gomega.Expect(implementsHook).To(gomega.BeTrue())
 			})
 


### PR DESCRIPTION
### Description

This adds generic client support for the VLAN API. Also adds `corev1.Location`, as VLAN needs it.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
