### PR TITLE
⬆️🔥: upgrade gh/satori/go.uuid and remove usages of it where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ e.g.
   - core/location
   - vlan
 
+### Changed
+* github.com/satori/go.uuid updated to latest master
+  - fixes a security issue for random UUIDs being not that random (CVE-2021-3538, https://github.com/satori/go.uuid/issues/73)
+    + although this is a real security issue, it's not relevant for go-anxcloud as it only consumes UUIDs in production code
+    + UUIDs were generated in test code, but those not being as random as they should be isn't a real problem
+  - the library seems dead and all usages not part of a public interface have been removed from go-anxcloud to
+    prepare removing it completely when the legacy CloudDNS client is gone
+
 ## [0.4.0] - 2022-01-24
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/go-logr/stdr v1.2.0
 	github.com/onsi/ginkgo/v2 v2.0.0
 	github.com/onsi/gomega v1.17.0
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 )

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/api/object.go
+++ b/pkg/api/object.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 
-	uuid "github.com/satori/go.uuid"
 	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
@@ -70,8 +69,7 @@ fields:
 				}
 
 				allowedIdentifierTypes := map[reflect.Type]func(interface{}) string{
-					reflect.TypeOf(""):       func(v interface{}) string { return v.(string) },
-					reflect.TypeOf(uuid.Nil): func(v interface{}) string { return v.(uuid.UUID).String() },
+					reflect.TypeOf(""): func(v interface{}) string { return v.(string) },
 				}
 
 				for ft, vf := range allowedIdentifierTypes {

--- a/pkg/apis/clouddns/v1/mocks_test.go
+++ b/pkg/apis/clouddns/v1/mocks_test.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
-
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
 )
@@ -263,14 +261,14 @@ func mock_create_record(zone string, record Record) {
 			IsMaster: true,
 
 			Revisions: []Revision{{
-				Identifier: uuid.NewV4().String(),
+				Identifier: "random revision identifier",
 				Records: []Record{{
 					Name:       record.Name,
 					Type:       record.Type,
 					RData:      record.RData,
 					Region:     record.Region,
 					TTL:        record.TTL,
-					Identifier: uuid.NewV4().String(),
+					Identifier: "random record identifier",
 				}},
 				ModifiedAt: time.Now(),
 				Serial:     1,
@@ -292,7 +290,7 @@ func mock_update_record(zone string, recordIdentifier string, record Record) {
 			Name:     zone,
 			IsMaster: true,
 			Revisions: []Revision{{
-				Identifier: uuid.NewV4().String(),
+				Identifier: "random revision identifier",
 				Records: []Record{{
 					Name:       record.Name,
 					Type:       record.Type,

--- a/pkg/clouddns/zone/mocks_test.go
+++ b/pkg/clouddns/zone/mocks_test.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
-
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/ghttp"
+	uuid "github.com/satori/go.uuid"
 )
 
 var mock *mockserver
@@ -167,7 +166,7 @@ func mock_apply_changeset(zone string, changes ChangeSet) {
 				Region:     changes.Create[0].Region,
 				RData:      changes.Create[0].RData,
 				TTL:        &changes.Create[0].TTL,
-				Identifier: uuid.NewV4(),
+				Identifier: mock_identifier(),
 				Immutable:  false,
 			},
 		}),
@@ -184,7 +183,7 @@ func mock_import_zone(zone string, data Import) {
 		ghttp.VerifyJSONRepresenting(data),
 		ghttp.RespondWithJSONEncoded(200, Revision{
 			CreatedAt:  time.Now(),
-			Identifier: uuid.NewV4(),
+			Identifier: mock_identifier(),
 			ModifiedAt: time.Now(),
 			Serial:     1,
 			State:      "active",
@@ -224,14 +223,14 @@ func mock_create_record(zone string, record RecordRequest) {
 				IsMaster: true,
 			},
 			Revisions: []Revision{{
-				Identifier: uuid.NewV4(),
+				Identifier: mock_identifier(),
 				Records: []Record{{
 					Name:       record.Name,
 					Type:       record.Type,
 					RData:      record.RData,
 					Region:     record.Region,
 					TTL:        &record.TTL,
-					Identifier: uuid.NewV4(),
+					Identifier: mock_identifier(),
 				}},
 				ModifiedAt: time.Now(),
 				Serial:     1,
@@ -256,7 +255,7 @@ func mock_update_record(zone string, recordIdentifier uuid.UUID, record RecordRe
 				IsMaster: true,
 			},
 			Revisions: []Revision{{
-				Identifier: uuid.NewV4(),
+				Identifier: mock_identifier(),
 				Records: []Record{{
 					Name:       record.Name,
 					Type:       record.Type,
@@ -282,4 +281,10 @@ func mock_delete_record(zone string, recordIdentifier uuid.UUID) {
 		ghttp.VerifyRequest("DELETE", fmt.Sprintf("/api/clouddns/v1/zone.json/%s/records/%s", zone, recordIdentifier)),
 		ghttp.RespondWith(200, nil),
 	))
+}
+
+func mock_identifier() uuid.UUID {
+	u, err := uuid.NewV4()
+	Expect(err).NotTo(HaveOccurred())
+	return u
 }


### PR DESCRIPTION
### Description

That library seems dead and we have to replace it, which would be a breaking change as it's part of the public interface of the old CloudDNS client.

For now, upgrading to latest master version fixes a security issue.

This PR also removes all usages not part of a public interface, so removing the whole dependency will be possible when the (already deprecated) old CloudDNS client is gone.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

* with SYSENG-1023 I planned to replace the UUID package, but after this PR merged and the already deprecated old clients removed, we can remove the dependency instead of replacing it

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
