### PR TITLE
💥✨: rename corev1.Info to corev1.Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+* **breaking**: renamed corev1.Info to corev1.Resource (#113, @LittleFox94)
+
 <!--
 Please add your release notes under the correct category (Added, Changed, ...) and use the following format as a
 guideline:

--- a/pkg/apis/core/v1/resource_e2e_test.go
+++ b/pkg/apis/core/v1/resource_e2e_test.go
@@ -32,10 +32,10 @@ var _ = Describe("resource E2E tests", func() {
 
 		It("should list resource using generic API client", func() {
 			var pageIter types.PageInfo
-			err := apiClient.List(ctx, &Info{}, api.Paged(1, 100, &pageIter))
+			err := apiClient.List(ctx, &Resource{}, api.Paged(1, 100, &pageIter))
 			Expect(err).ToNot(HaveOccurred())
 
-			var resInfo []Info
+			var resInfo []Resource
 			Expect(pageIter.Next(&resInfo)).To(BeTrue())
 			Expect(resInfo).ToNot(BeEmpty())
 			Expect(resInfo[0].Identifier).ToNot(BeEmpty())

--- a/pkg/apis/core/v1/resource_genclient.go
+++ b/pkg/apis/core/v1/resource_genclient.go
@@ -9,7 +9,7 @@ import (
 	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
-func (i Info) EndpointURL(ctx context.Context) (*url.URL, error) {
+func (r Resource) EndpointURL(ctx context.Context) (*url.URL, error) {
 	u, err := url.ParseRequestURI("/api/core/v1/resource.json")
 	if err != nil {
 		return nil, err
@@ -29,12 +29,12 @@ func (i Info) EndpointURL(ctx context.Context) (*url.URL, error) {
 	if op == types.OperationList {
 		query := u.Query()
 
-		if len(i.Tags) > 1 {
+		if len(r.Tags) > 1 {
 			logr.FromContextOrDiscard(ctx).Info("Listing with multiple tags isn't supported. Only first one used")
 		}
 
-		if len(i.Tags) > 0 {
-			query.Add("tag_name", i.Tags[0])
+		if len(r.Tags) > 0 {
+			query.Add("tag_name", r.Tags[0])
 		}
 		u.RawQuery = query.Encode()
 	}

--- a/pkg/apis/core/v1/resource_test.go
+++ b/pkg/apis/core/v1/resource_test.go
@@ -21,15 +21,15 @@ var _ = Describe("resource.Info", func() {
 		})
 
 		It("throws an error for Create operation", func() {
-			err := apiClient.Create(context.TODO(), &Info{Identifier: "foo"})
+			err := apiClient.Create(context.TODO(), &Resource{Identifier: "foo"})
 			Expect(err).To(BeEquivalentTo(api.ErrOperationNotSupported))
 		})
 		It("throws an error for Update operation", func() {
-			err := apiClient.Update(context.TODO(), &Info{Identifier: "foo"})
+			err := apiClient.Update(context.TODO(), &Resource{Identifier: "foo"})
 			Expect(err).To(BeEquivalentTo(api.ErrOperationNotSupported))
 		})
 		It("throws an error for Destroy operation", func() {
-			err := apiClient.Destroy(context.TODO(), &Info{Identifier: "foo"})
+			err := apiClient.Destroy(context.TODO(), &Resource{Identifier: "foo"})
 			Expect(err).To(BeEquivalentTo(api.ErrOperationNotSupported))
 		})
 	})

--- a/pkg/apis/core/v1/resource_types.go
+++ b/pkg/apis/core/v1/resource_types.go
@@ -1,5 +1,7 @@
 package v1
 
+import "encoding/json"
+
 // Type is part of info.
 type Type struct {
 	Identifier string `json:"identifier"`
@@ -8,10 +10,11 @@ type Type struct {
 
 // anxcloud:object
 
-// Info contains all information about a resource.
-type Info struct {
-	Identifier string   `json:"identifier" anxcloud:"identifier"`
-	Name       string   `json:"name"`
-	Type       Type     `json:"resource_type"`
-	Tags       []string `json:"tags"`
+// Resource contains all information about a resource.
+type Resource struct {
+	Identifier string          `json:"identifier" anxcloud:"identifier"`
+	Name       string          `json:"name"`
+	Type       Type            `json:"resource_type"`
+	Tags       []string        `json:"tags"`
+	Attributes json.RawMessage `json:"attributes"`
 }

--- a/pkg/apis/core/v1/xxgenerated_object_test.go
+++ b/pkg/apis/core/v1/xxgenerated_object_test.go
@@ -19,8 +19,8 @@ var _ = Describe("Object Location", func() {
 	testutils.ObjectTests(&o, ifaces...)
 })
 
-var _ = Describe("Object Info", func() {
-	o := Info{}
+var _ = Describe("Object Resource", func() {
+	o := Resource{}
 
 	ifaces := make([]interface{}, 0, 1)
 	{

--- a/pkg/core/resource/resource.go
+++ b/pkg/core/resource/resource.go
@@ -15,7 +15,7 @@ const pathPrefix = "/api/core/v1/resource.json"
 
 type (
 	Type = v1.Type
-	Info = v1.Info
+	Info = v1.Resource
 )
 
 // Summary describes a resource in short.


### PR DESCRIPTION
### Description

No one knew why it was named Info in the first place, Resource fits better as the API calles it that, too.

Also adds the Attributes field to corev1.Resource as json.RawMessage to decode into an Object without an extra call to the API.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References
<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
* introduced in #67, I missed the name while reviewing

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
