### PR TITLE
Tag objects with generic client

### DIFF
--- a/pkg/apis/core/v1/resource_test.go
+++ b/pkg/apis/core/v1/resource_test.go
@@ -2,16 +2,18 @@ package v1
 
 import (
 	"context"
+	"strings"
 
 	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
 	"go.anx.io/go-anxcloud/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("resource.Info", func() {
-	When("doing unsupported operations on Info objects", func() {
+var _ = Describe("resource.Resource", func() {
+	Context("doing unsupported operations on Info objects", func() {
 		var apiClient api.API
 
 		BeforeEach(func() {
@@ -32,5 +34,66 @@ var _ = Describe("resource.Info", func() {
 			err := apiClient.Destroy(context.TODO(), &Resource{Identifier: "foo"})
 			Expect(err).To(BeEquivalentTo(api.ErrOperationNotSupported))
 		})
+	})
+
+	It("decodes correctly", func() {
+		msg := `{
+	"name":"test",
+	"identifier":"some identifier string",
+	"resource_type":{
+		"identifier":"some other identifier string",
+		"name":"Service Resource"
+	},
+	"service_name":"Service",
+	"deleted_at":null,
+	"updated_at":"2022-03-23 12:19:00",
+	"created_at":"2022-03-23 12:18:59",
+	"reseller":{
+		"customer_id":"421337",
+		"demo":false,
+		"identifier":"yet another identifier",
+		"name":"Some reseller name",
+		"name_slug":"some_reseller_name",
+		"reseller":null
+	},
+	"customer":{
+		"customer_id":"133742",
+		"demo":false,
+		"identifier":"even yet another identifier",
+		"name":"Some customer name",
+		"name_slug":"some_customer_name",
+		"reseller":"yet another identifier"
+	},
+	"billing_contract":null,
+	"managed_status":"unmanaged",
+	"shared_by":null,
+	"shared_at":null,
+	"resource_pools":[],
+	"attributes":null,
+	"tags":[
+		{
+			"name":"some-tag",
+			"identifier":"we sure have a lot of identifiers"
+		},
+		{
+			"name":"some-other-tag",
+			"identifier":"we sure have a lot of identifiers ..."
+		}
+	]
+}`
+
+		r := Resource{}
+		err := r.DecodeAPIResponse(
+			types.ContextWithOperation(context.TODO(), types.OperationGet),
+			strings.NewReader(msg),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(r.Name).To(Equal("test"))
+		Expect(r.Identifier).To(Equal("some identifier string"))
+		Expect(r.Type.Name).To(Equal("Service Resource"))
+		Expect(r.Type.Identifier).To(Equal("some other identifier string"))
+		Expect(r.Tags).To(Equal([]string{"some-tag", "some-other-tag"}))
+
 	})
 })

--- a/pkg/apis/core/v1/resource_types.go
+++ b/pkg/apis/core/v1/resource_types.go
@@ -18,3 +18,14 @@ type Resource struct {
 	Tags       []string        `json:"tags"`
 	Attributes json.RawMessage `json:"attributes"`
 }
+
+// anxcloud:object:hooks=RequestFilterHook,ResponseFilterHook
+
+// ResourceWithTag is a virtual Object used to add (Create) or remove (Destroy) a tag to/from a Resource.
+type ResourceWithTag struct {
+	// Identifier of the Resource which tags to change
+	Identifier string `anxcloud:"identifier"`
+
+	// Name of the Tag to add or remove from the resource
+	Tag string
+}

--- a/pkg/apis/core/v1/resource_types.go
+++ b/pkg/apis/core/v1/resource_types.go
@@ -8,7 +8,7 @@ type Type struct {
 	Name       string `json:"name"`
 }
 
-// anxcloud:object
+// anxcloud:object:hooks=ResponseDecodeHook
 
 // Resource contains all information about a resource.
 type Resource struct {

--- a/pkg/apis/core/v1/xxgenerated_object_test.go
+++ b/pkg/apis/core/v1/xxgenerated_object_test.go
@@ -34,3 +34,23 @@ var _ = Describe("Object Resource", func() {
 
 	testutils.ObjectTests(&o, ifaces...)
 })
+
+var _ = Describe("Object ResourceWithTag", func() {
+	o := ResourceWithTag{}
+
+	ifaces := make([]interface{}, 0, 3)
+	{
+		var i types.Object
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.RequestFilterHook
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.ResponseFilterHook
+		ifaces = append(ifaces, &i)
+	}
+
+	testutils.ObjectTests(&o, ifaces...)
+})

--- a/pkg/apis/core/v1/xxgenerated_object_test.go
+++ b/pkg/apis/core/v1/xxgenerated_object_test.go
@@ -22,9 +22,13 @@ var _ = Describe("Object Location", func() {
 var _ = Describe("Object Resource", func() {
 	o := Resource{}
 
-	ifaces := make([]interface{}, 0, 1)
+	ifaces := make([]interface{}, 0, 2)
 	{
 		var i types.Object
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.ResponseDecodeHook
 		ifaces = append(ifaces, &i)
 	}
 

--- a/pkg/utils/test/object.go
+++ b/pkg/utils/test/object.go
@@ -91,9 +91,10 @@ func testHookHandlingIncompleteContext(o types.Object, hook string) {
 				// It can be fine with incomplete context, but if it fails, than with the error indicating
 				// it checked for it - the one OperationFromContext and co. return
 				if err != nil {
-					gomega.Expect(err).To(
+					gomega.Expect(err).To(gomega.Or(
 						gomega.MatchError(types.ErrContextKeyNotSet),
-					)
+						gomega.MatchError(api.ErrOperationNotSupported),
+					))
 				}
 			},
 


### PR DESCRIPTION
### Description

This adds support for tagging objects via generic client.

Also fixes a bug with retrieving objects via core/v1.Resource - tags were not decoded correctly.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

* bad decoding introduced in #67 
* SYSENG-1152

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
