### PR TITLE
Export some pkg/api.HTTPError things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* generic client: ErrorFromResponse and NewHTTPError to allow easier mocking (#118, @LittleFox94)
+
 ### Changed
 * **breaking**: renamed corev1.Info to corev1.Resource (#113, @LittleFox94)
 

--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -386,7 +386,7 @@ func (a defaultAPI) doRequest(req *http.Request, obj types.Object, body interfac
 
 	defer response.Body.Close()
 
-	if err := errorFromResponse(req, response); err != nil {
+	if err := ErrorFromResponse(req, response); err != nil {
 		return err
 	}
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -123,7 +123,8 @@ func (e HTTPError) Error() string {
 	return e.message
 }
 
-func errorFromResponse(req *http.Request, res *http.Response) error {
+// ErrorFromResponse creates a new HTTPError from the given response.
+func ErrorFromResponse(req *http.Request, res *http.Response) error {
 	var specificError error
 
 	switch res.StatusCode {
@@ -139,4 +140,15 @@ func errorFromResponse(req *http.Request, res *http.Response) error {
 	}
 
 	return nil
+}
+
+// NewHTTPError creates a new HTTPError instance with the given values, which is mostly useful for mock-testing.
+func NewHTTPError(status int, method string, url *url.URL, wrapped error) error {
+	return HTTPError{
+		message:    http.StatusText(status),
+		wrapped:    wrapped,
+		statusCode: status,
+		url:        url,
+		method:     method,
+	}
 }

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -105,7 +105,7 @@ var _ = Describe("HTTPError", func() {
 	})
 })
 
-var _ = Describe("errorFromResponse function", func() {
+var _ = Describe("ErrorFromResponse function", func() {
 	req := httptest.NewRequest("GET", "/", nil)
 
 	var statusCode int
@@ -123,7 +123,7 @@ var _ = Describe("errorFromResponse function", func() {
 		})
 
 		It("returns ErrNotFound as expected", func() {
-			err := errorFromResponse(req, res)
+			err := ErrorFromResponse(req, res)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(ErrNotFound))
 		})
@@ -135,7 +135,7 @@ var _ = Describe("errorFromResponse function", func() {
 		})
 
 		It("returns ErrAccessDenied as expected", func() {
-			err := errorFromResponse(req, res)
+			err := ErrorFromResponse(req, res)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(ErrAccessDenied))
 		})
@@ -147,7 +147,7 @@ var _ = Describe("errorFromResponse function", func() {
 		})
 
 		It("returns a matching HTTPError as expected", func() {
-			err := errorFromResponse(req, res)
+			err := ErrorFromResponse(req, res)
 			Expect(err).To(HaveOccurred())
 
 			var he HTTPError


### PR DESCRIPTION
### Description

Exporting ErrorFromResponse() and (the new) NewHTTPError() simplifies
mocking a lot and makes mocking a generic client possible.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

Again needed for CCM but also just good to have.

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
