### PR TITLE
🐛: fill Identifier for CDNS Record via genclient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+* clouddns/v1: creating a Record didn't retrieve its Identifier (#120, @LittleFox94)
+
 <!--
 Please add your release notes under the correct category (Added, Changed, ...) and use the following format as a
 guideline:

--- a/pkg/apis/clouddns/v1/mocks_test.go
+++ b/pkg/apis/clouddns/v1/mocks_test.go
@@ -257,15 +257,17 @@ func mock_create_record(zone string, record Record) {
 		ghttp.VerifyRequest("POST", fmt.Sprintf("/api/clouddns/v1/zone.json/%s/records", zone)),
 		ghttp.VerifyJSONRepresenting(record),
 		ghttp.RespondWithJSONEncoded(200, Zone{
-			Name:     zone,
-			IsMaster: true,
+			Name:            zone,
+			IsMaster:        true,
+			CurrentRevision: "random revision identifier",
 
 			Revisions: []Revision{{
 				Identifier: "random revision identifier",
 				Records: []Record{{
-					Name:       record.Name,
-					Type:       record.Type,
-					RData:      record.RData,
+					Name: record.Name,
+					Type: record.Type,
+					// we test with TXT records, for which the Engine returns RData enclosed in quotes
+					RData:      fmt.Sprintf("%q", record.RData),
 					Region:     record.Region,
 					TTL:        record.TTL,
 					Identifier: "random record identifier",
@@ -287,14 +289,17 @@ func mock_update_record(zone string, recordIdentifier string, record Record) {
 		ghttp.VerifyRequest("PUT", fmt.Sprintf("/api/clouddns/v1/zone.json/%s/records/%s", zone, recordIdentifier)),
 		ghttp.VerifyJSONRepresenting(record),
 		ghttp.RespondWithJSONEncoded(200, Zone{
-			Name:     zone,
-			IsMaster: true,
+			Name:            zone,
+			IsMaster:        true,
+			CurrentRevision: "random revision identifier",
+
 			Revisions: []Revision{{
 				Identifier: "random revision identifier",
 				Records: []Record{{
-					Name:       record.Name,
-					Type:       record.Type,
-					RData:      record.RData,
+					Name: record.Name,
+					Type: record.Type,
+					// we test with TXT records, for which the Engine returns RData enclosed in quotes
+					RData:      fmt.Sprintf("%q", record.RData),
 					Region:     record.Region,
 					TTL:        record.TTL,
 					Identifier: record.Identifier,

--- a/pkg/apis/clouddns/v1/record_genclient.go
+++ b/pkg/apis/clouddns/v1/record_genclient.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -10,6 +11,18 @@ import (
 
 	"go.anx.io/go-anxcloud/pkg/api"
 	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/utils/object/compare"
+)
+
+var (
+	// ErrModifyRevisionNotFound is returned for Create and Update requests when the zones CurrentRevision is not
+	// found in the set of Revisions. This is probably an Engine problem and not your code.
+	ErrModifyRevisionNotFound = errors.New("revision not found")
+
+	// ErrModifyRecordNotFound is returned for Create and Update requests when the modified Record is not found in
+	// the zones current Revision. This is probably an Engine problem and not your code, but might be a problem in
+	// these API bindings.
+	ErrModifyRecordNotFound = errors.New("revision not found")
 )
 
 func (r *Record) EndpointURL(ctx context.Context) (*url.URL, error) {
@@ -48,13 +61,31 @@ func (r *Record) EndpointURL(ctx context.Context) (*url.URL, error) {
 }
 
 func (r *Record) DecodeAPIResponse(ctx context.Context, data io.Reader) error {
-	// Response to POST and PUT are the _Zone_ details, which contain some of the updated Record details, but not all
-	// To work around these inconsistencies, we just leave the receiver as it is
 	op, err := types.OperationFromContext(ctx)
 	if err != nil {
 		return err
 	}
+
+	// Response to POST and PUT are the _Zone_ details, which contain some of the updated Record details, but not all.
+	// We have to find our Record in the current revision of the zone and grab some values from it, notably the Identifier
+	// and RData (as the Engine might change its format).
 	if op == types.OperationCreate || op == types.OperationUpdate {
+		var zone Zone
+		err := json.NewDecoder(data).Decode(&zone)
+		if err != nil {
+			return nil
+		}
+
+		responseRecord, err := r.findInZone(&zone)
+		if err != nil {
+			return err
+		}
+
+		r.Identifier = responseRecord.Identifier
+
+		// Engine changes RData sometimes
+		r.RData = responseRecord.RData
+
 		return nil
 	}
 
@@ -77,4 +108,33 @@ func (r *Record) DecodeAPIResponse(ctx context.Context, data io.Reader) error {
 
 func (r *Record) HasPagination(ctx context.Context) (bool, error) {
 	return false, nil
+}
+
+func (r *Record) findInZone(zone *Zone) (*Record, error) {
+	var rev *Revision
+	for _, r := range zone.Revisions {
+		if r.Identifier == zone.CurrentRevision {
+			rev = &r
+		}
+	}
+
+	if rev == nil {
+		return nil, ErrModifyRevisionNotFound
+	}
+
+	changedR := *r
+
+	if r.Type == "TXT" {
+		// Engine returns TXT RData enclosed in quotes
+		changedR.RData = fmt.Sprintf("%q", r.RData)
+	}
+
+	idx, err := compare.Search(changedR, rev.Records, "Name", "Type", "RData", "TTL")
+	if err != nil {
+		return nil, fmt.Errorf("error searching record in response: %w", err)
+	} else if idx == -1 {
+		return nil, ErrModifyRecordNotFound
+	}
+
+	return &rev.Records[idx], nil
 }

--- a/pkg/apis/clouddns/v1/zone_test.go
+++ b/pkg/apis/clouddns/v1/zone_test.go
@@ -290,6 +290,8 @@ var _ = Describe("CloudDNS API client", func() {
 
 			err := a.Create(ctx, &record)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(record.Identifier).NotTo(BeEmpty())
+			Expect(record.RData).To(Equal(`"test record"`))
 
 			mock_expect_request_count(1)
 		})


### PR DESCRIPTION
### Description

Generic client bindings for CloudDNS didn't use the response body for Record Create and Update requests, making it hard to get the identifier of a newly created Record.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

* [SYSENG-1187](https://ats.anexia-it.com/browse/SYSENG-1187)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
