### PR TITLE
Allow single dns records to be fetched by identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * clouddns/v1: creating a Record didn't retrieve its Identifier (#120, @LittleFox94)
 
+### Added
+* generic client: introduce FilterRequestURLHook to allow URL modification of the resource endpoint (#121, @marioreggiori)
+* clouddns/v1: allow single dns records to be fetched by identifier (#121, @marioreggiori)
+
 <!--
 Please add your release notes under the correct category (Added, Changed, ...) and use the following format as a
 guideline:

--- a/pkg/api/api_implementation.go
+++ b/pkg/api/api_implementation.go
@@ -298,6 +298,14 @@ func (a defaultAPI) makeRequest(ctx context.Context, obj types.Object, body inte
 		// Fragment is never sent to a server
 	}
 
+	if obj, ok := obj.(types.FilterRequestURLHook); ok {
+		filteredURL, err := obj.FilterRequestURL(ctx, &fullURL)
+		if err != nil {
+			return nil, err
+		}
+		fullURL = *filteredURL
+	}
+
 	var method string
 	hasRequestBody := false
 

--- a/pkg/api/types/object.go
+++ b/pkg/api/types/object.go
@@ -55,3 +55,7 @@ type PaginationSupportHook interface {
 type ResponseDecodeHook interface {
 	DecodeAPIResponse(ctx context.Context, data io.Reader) error
 }
+
+type FilterRequestURLHook interface {
+	FilterRequestURL(ctx context.Context, url *url.URL) (*url.URL, error)
+}

--- a/pkg/apis/clouddns/v1/mocks_test.go
+++ b/pkg/apis/clouddns/v1/mocks_test.go
@@ -187,9 +187,9 @@ func mock_list_records(zone string) {
 		ghttp.RespondWithJSONEncoded(200, []Record{
 			{Name: "", Type: "A", RData: "127.0.0.1"},
 			{Name: "", Type: "AAAA", RData: "::1"},
-			{Name: "www", Type: "A", RData: "127.0.0.1"},
+			{Name: "www", Type: "A", RData: "127.0.0.1", Identifier: "abcd-efgh-ijkl-mnop"},
 			{Name: "www", Type: "AAAA", RData: "::1"},
-			{Name: "test1", Type: "TXT", RData: "\"test record\""},
+			{Name: "test1", Type: "TXT", RData: "\"test record\"", Identifier: "test-record-identifier"},
 		}),
 	))
 }

--- a/pkg/apis/clouddns/v1/record_types.go
+++ b/pkg/apis/clouddns/v1/record_types.go
@@ -1,6 +1,6 @@
 package v1
 
-// anxcloud:object:hooks=ResponseDecodeHook,PaginationSupportHook
+// anxcloud:object:hooks=ResponseDecodeHook,PaginationSupportHook,FilterRequestURLHook
 
 type Record struct {
 	Identifier string `json:"identifier,omitempty" anxcloud:"identifier"`

--- a/pkg/apis/clouddns/v1/xxgenerated_object_test.go
+++ b/pkg/apis/clouddns/v1/xxgenerated_object_test.go
@@ -10,7 +10,7 @@ import (
 var _ = Describe("Object Record", func() {
 	o := Record{}
 
-	ifaces := make([]interface{}, 0, 3)
+	ifaces := make([]interface{}, 0, 4)
 	{
 		var i types.Object
 		ifaces = append(ifaces, &i)
@@ -21,6 +21,10 @@ var _ = Describe("Object Record", func() {
 	}
 	{
 		var i types.PaginationSupportHook
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.FilterRequestURLHook
 		ifaces = append(ifaces, &i)
 	}
 

--- a/pkg/apis/clouddns/v1/zone_test.go
+++ b/pkg/apis/clouddns/v1/zone_test.go
@@ -347,10 +347,12 @@ var _ = Describe("CloudDNS API client", func() {
 	})
 
 	Context("with some records existing", func() {
+		var firstRecordIdentifier string
+
 		JustBeforeEach(func() {
 			ensureTestZone(a, zoneName, times)
 
-			_ = ensureTestRecord(a, Record{
+			firstRecordIdentifier = ensureTestRecord(a, Record{
 				Name:     "test1",
 				ZoneName: zoneName,
 				Type:     "TXT",
@@ -394,6 +396,21 @@ var _ = Describe("CloudDNS API client", func() {
 				Region:   "default",
 				TTL:      300,
 			})
+		})
+
+		It("gets a record by it's identifier", func() {
+			mock_list_records(zoneName)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+			defer cancel()
+
+			record := &Record{Identifier: firstRecordIdentifier, ZoneName: zoneName}
+			if !isIntegrationTest {
+				record.Identifier = "test-record-identifier"
+			}
+			err := a.Get(ctx, record)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(record.Name).To(Equal("test1"))
+			Expect(record.Type).To(Equal("TXT"))
 		})
 
 		It("lists all records of the zone", func() {

--- a/pkg/utils/test/object.go
+++ b/pkg/utils/test/object.go
@@ -81,6 +81,10 @@ func testHookHandlingIncompleteContext(o types.Object, hook string) {
 			_, err := o.(types.ResponseFilterHook).FilterAPIResponse(ctx, rec.Result())
 			return err
 		},
+		"FilterRequestURLHook": func(ctx context.Context) error {
+			_, err := o.(types.FilterRequestURLHook).FilterRequestURL(ctx, &url.URL{})
+			return err
+		},
 	}
 
 	if errorCheck, ok := supportedHooks[hook]; ok {


### PR DESCRIPTION
- allow single dns records to be fetched by identifier
- introduce FilterRequestURLHook-hook for generic api

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
