### PR TITLE
dependabot: no integration tests and go.anx.io update

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,8 +14,11 @@ jobs:
   integration-trusted:
     runs-on: ubuntu-latest
     if: >
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-      || github.event_name == 'push' 
+      (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        || github.event_name == 'push'
+      ) &&
+      github.actor != 'dependabot[bot]'
     strategy:
       matrix:
         go:

--- a/.github/workflows/update-go.anx.io.yml
+++ b/.github/workflows/update-go.anx.io.yml
@@ -7,6 +7,7 @@ jobs:
   trigger:
     name:    Trigger go.anx.io update
     runs-on: ubuntu-latest
+    if:      github.actor != 'dependabot[bot]'
     steps:
     - uses: anexia-it/go.anx.io@main
       env:


### PR DESCRIPTION
### Description

This PR disables (trusted, still possible via ok-to-test) integration tests and go.anx.io updates for dependabot branches/PRs.

It is needed as dependabot has it's own collection of secrets and I don't want to duplicate them for it. Unit tests should be enough, we can still trigger integration tests with slash command if needed and we certainly don't need dependabot branches in go.anx.io

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
