### PR TITLE
fix clouddns ErrModifyRecordNotFound error message revision->record

### DIFF
--- a/pkg/apis/clouddns/v1/record_genclient.go
+++ b/pkg/apis/clouddns/v1/record_genclient.go
@@ -22,7 +22,7 @@ var (
 	// ErrModifyRecordNotFound is returned for Create and Update requests when the modified Record is not found in
 	// the zones current Revision. This is probably an Engine problem and not your code, but might be a problem in
 	// these API bindings.
-	ErrModifyRecordNotFound = errors.New("revision not found")
+	ErrModifyRecordNotFound = errors.New("record not found")
 )
 
 func (r *Record) EndpointURL(ctx context.Context) (*url.URL, error) {


### PR DESCRIPTION
### Description

Fix `ErrModifyRecordNotFound` error message in generic clouddns/v1 API

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
