### PR TITLE
SYSENG-1230: fix missing LBaaS Backend attributes for Create operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * clouddns/v1: creating a Record didn't retrieve its Identifier (#120, @LittleFox94)
+* lbaas/v1: fix some attributes not being sent to the Engine when creating Backends (#135, @LittleFox94)
 
 ### Added
 * generic client: FilterRequestURLHook for modifying request URLs (#123, @marioreggiori)

--- a/pkg/apis/lbaas/v1/backend_genclient.go
+++ b/pkg/apis/lbaas/v1/backend_genclient.go
@@ -49,26 +49,19 @@ func (b *Backend) FilterAPIRequestBody(ctx context.Context) (interface{}, error)
 		return nil, err
 	}
 
-	if op == types.OperationCreate {
-		return struct {
-			Name         string `json:"name"`
-			LoadBalancer string `json:"load_balancer"`
-			Mode         Mode   `json:"mode"`
-			State        State  `json:"state"`
-		}{
-			Name:         b.Name,
-			Mode:         b.Mode,
-			LoadBalancer: b.LoadBalancer.Identifier,
-			State:        NewlyCreated,
-		}, nil
-	} else if op == types.OperationUpdate {
-		return struct {
+	if op == types.OperationCreate || op == types.OperationUpdate {
+		ret := struct {
 			Backend
 			LoadBalancer string `json:"load_balancer"`
+
+			// we never want to send the state field, so making sure to omit it here
+			State string `json:"state,omitempty"`
 		}{
 			Backend:      *b,
 			LoadBalancer: b.LoadBalancer.Identifier,
-		}, nil
+		}
+
+		return ret, nil
 	}
 
 	return b, nil

--- a/pkg/apis/lbaas/v1/backend_types.go
+++ b/pkg/apis/lbaas/v1/backend_types.go
@@ -6,13 +6,13 @@ package v1
 type Backend struct {
 	HasState
 
-	CustomerIdentifier string     `json:"customer_identifier"`
-	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier" anxcloud:"identifier"`
+	CustomerIdentifier string     `json:"customer_identifier,omitempty"`
+	ResellerIdentifier string     `json:"reseller_identifier,omitempty"`
+	Identifier         string     `json:"identifier,omitempty" anxcloud:"identifier"`
 	Name               string     `json:"name"`
-	HealthCheck        string     `json:"health_check"`
+	HealthCheck        string     `json:"health_check,omitempty"`
 	Mode               Mode       `json:"mode"`
-	ServerTimeout      int        `json:"server_timeout"`
+	ServerTimeout      int        `json:"server_timeout,omitempty"`
 	AutomationRules    []RuleInfo `json:"automation_rules,omitempty"`
 
 	// Only the name and identifier fields are used and returned.

--- a/pkg/apis/lbaas/v1/backend_types.go
+++ b/pkg/apis/lbaas/v1/backend_types.go
@@ -4,6 +4,7 @@ package v1
 
 // The Backend resource configures settings common for all specific backend Server resources linked to it.
 type Backend struct {
+	commonMethods
 	HasState
 
 	CustomerIdentifier string     `json:"customer_identifier,omitempty"`

--- a/pkg/apis/lbaas/v1/bind_genclient.go
+++ b/pkg/apis/lbaas/v1/bind_genclient.go
@@ -1,16 +1,13 @@
 package v1
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"net/http"
 	"net/url"
 
 	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
-func (b Bind) EndpointURL(ctx context.Context) (*url.URL, error) {
+func (b *Bind) EndpointURL(ctx context.Context) (*url.URL, error) {
 
 	// EndpointURL returns the URL where to retrieve objects of type Frontend and the identifier of the given Frontend.
 	// It implements the api.Object interface on *Frontend, making it usable with the generic API client.
@@ -38,43 +35,16 @@ func (b Bind) EndpointURL(ctx context.Context) (*url.URL, error) {
 	return u, nil
 }
 
-// FilterAPIRequestBody generates the request body for creating a new FrontendBind, which differs from the Bind object.
+// FilterAPIRequestBody generates the request body for Binds, replacing linked Objects with just their identifier.
 func (b *Bind) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
-	op, err := types.OperationFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if op == types.OperationCreate || op == types.OperationUpdate {
-		return struct {
+	return requestBody(ctx, func() interface{} {
+		return &struct {
+			commonRequestBody
 			Bind
 			Frontend string `json:"frontend"`
-
-			// we never want to send the state field, so making sure to omit it here
-			State string `json:"state,omitempty"`
 		}{
 			Bind:     *b,
 			Frontend: b.Frontend.Identifier,
-		}, nil
-	}
-
-	return b, nil
-}
-
-func (b *Bind) FilterAPIResponse(ctx context.Context, res *http.Response) (*http.Response, error) {
-	op, err := types.OperationFromContext(ctx)
-	if err != nil {
-		return res, err
-	}
-
-	if op == types.OperationDestroy {
-		err = res.Body.Close()
-		if err != nil {
-			return res, err
 		}
-
-		res.Body = io.NopCloser(bytes.NewReader([]byte("{}")))
-		return res, nil
-	}
-	return res, nil
+	})
 }

--- a/pkg/apis/lbaas/v1/bind_genclient.go
+++ b/pkg/apis/lbaas/v1/bind_genclient.go
@@ -45,25 +45,16 @@ func (b *Bind) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
 		return nil, err
 	}
 
-	if op == types.OperationCreate {
+	if op == types.OperationCreate || op == types.OperationUpdate {
 		return struct {
 			Bind
 			Frontend string `json:"frontend"`
-			State    State  `json:"state"`
+
+			// we never want to send the state field, so making sure to omit it here
+			State string `json:"state,omitempty"`
 		}{
 			Bind:     *b,
 			Frontend: b.Frontend.Identifier,
-			State:    NewlyCreated,
-		}, nil
-	} else if op == types.OperationUpdate {
-		return struct {
-			Bind
-			Frontend string `json:"frontend"`
-			State    State  `json:"state"`
-		}{
-			Bind:     *b,
-			Frontend: b.Frontend.Identifier,
-			State:    Updating,
 		}, nil
 	}
 

--- a/pkg/apis/lbaas/v1/bind_types.go
+++ b/pkg/apis/lbaas/v1/bind_types.go
@@ -4,6 +4,7 @@ package v1
 
 // Bind represents an LBaaS FrontendBind
 type Bind struct {
+	commonMethods
 	HasState
 
 	CustomerIdentifier string     `json:"customer_identifier,omitempty"`

--- a/pkg/apis/lbaas/v1/bind_types.go
+++ b/pkg/apis/lbaas/v1/bind_types.go
@@ -6,9 +6,9 @@ package v1
 type Bind struct {
 	HasState
 
-	CustomerIdentifier string     `json:"customer_identifier"`
-	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier" anxcloud:"identifier"`
+	CustomerIdentifier string     `json:"customer_identifier,omitempty"`
+	ResellerIdentifier string     `json:"reseller_identifier,omitempty"`
+	Identifier         string     `json:"identifier,omitempty" anxcloud:"identifier"`
 	Name               string     `json:"name"`
 	Address            string     `json:"address"`
 	Port               int        `json:"port"`

--- a/pkg/apis/lbaas/v1/frontend_genclient.go
+++ b/pkg/apis/lbaas/v1/frontend_genclient.go
@@ -49,22 +49,14 @@ func (f *Frontend) FilterAPIRequestBody(ctx context.Context) (interface{}, error
 		return nil, err
 	}
 
-	if op == types.OperationCreate {
-		f.State = NewlyCreated
+	if op == types.OperationCreate || op == types.OperationUpdate {
 		return struct {
 			Frontend
 			LoadBalancer   string `json:"load_balancer"`
 			DefaultBackend string `json:"default_backend"`
-		}{
-			Frontend:       *f,
-			LoadBalancer:   f.LoadBalancer.Identifier,
-			DefaultBackend: f.DefaultBackend.Identifier,
-		}, nil
-	} else if op == types.OperationUpdate {
-		return struct {
-			Frontend
-			LoadBalancer   string `json:"load_balancer"`
-			DefaultBackend string `json:"default_backend"`
+
+			// we never want to send the state field, so making sure to omit it here
+			State string `json:"state,omitempty"`
 		}{
 			Frontend:       *f,
 			LoadBalancer:   f.LoadBalancer.Identifier,

--- a/pkg/apis/lbaas/v1/frontend_types.go
+++ b/pkg/apis/lbaas/v1/frontend_types.go
@@ -6,12 +6,12 @@ package v1
 type Frontend struct {
 	HasState
 
-	CustomerIdentifier string     `json:"customer_identifier"`
-	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier" anxcloud:"identifier"`
+	CustomerIdentifier string     `json:"customer_identifier,omitempty"`
+	ResellerIdentifier string     `json:"reseller_identifier,omitempty"`
+	Identifier         string     `json:"identifier,omitempty" anxcloud:"identifier"`
 	Name               string     `json:"name"`
 	Mode               Mode       `json:"mode"`
-	ClientTimeout      string     `json:"client_timeout"`
+	ClientTimeout      string     `json:"client_timeout,omitempty"`
 	AutomationRules    []RuleInfo `json:"automation_rules,omitempty"`
 
 	// Only the name and identifier fields are used and returned.

--- a/pkg/apis/lbaas/v1/frontend_types.go
+++ b/pkg/apis/lbaas/v1/frontend_types.go
@@ -4,6 +4,7 @@ package v1
 
 // Frontend represents a LBaaS Frontend.
 type Frontend struct {
+	commonMethods
 	HasState
 
 	CustomerIdentifier string     `json:"customer_identifier,omitempty"`

--- a/pkg/apis/lbaas/v1/helper.go
+++ b/pkg/apis/lbaas/v1/helper.go
@@ -1,0 +1,67 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+// commonMethods has methods overridden for all LBaaS objects in the same way
+type commonMethods struct{}
+
+func (cm *commonMethods) FilterAPIResponse(ctx context.Context, res *http.Response) (*http.Response, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationDestroy {
+		err = res.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		res.Body = io.NopCloser(bytes.NewReader([]byte("{}")))
+		return res, nil
+	}
+	return res, nil
+}
+
+// commonRequestBody is embedded in the request body types of LBaaS objects.
+type commonRequestBody struct {
+	// we want to send the correct state for Update operations, but none for Create operations
+	State string `json:"state,omitempty"`
+}
+
+func (crb *commonRequestBody) setState(state string) {
+	crb.State = state
+}
+
+type commonRequestBodyInterface interface {
+	setState(state string)
+}
+
+// requestBody returns the result of the given function, if a request body is needed (Create and Update operations).
+func requestBody(ctx context.Context, br func() interface{}) (interface{}, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationCreate || op == types.OperationUpdate {
+		response := br()
+
+		if op == types.OperationUpdate {
+			if crbi, ok := response.(commonRequestBodyInterface); ok {
+				crbi.setState(Updating.ID)
+			}
+		}
+
+		return response, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/apis/lbaas/v1/loadbalancer_genclient.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_genclient.go
@@ -17,9 +17,18 @@ func (lb *LoadBalancer) FilterAPIRequestBody(ctx context.Context) (interface{}, 
 	return requestBody(ctx, func() interface{} {
 		return &struct {
 			commonRequestBody
+
+			// nolint:govet
 			LoadBalancer
 		}{
 			LoadBalancer: *lb,
 		}
 	})
 }
+
+// We need the three methods below to have LoadBalancer implement the StateRetriever interface, too. All other
+// Objects get them via the embedded HasState instead.
+
+func (l LoadBalancer) StateSuccess() bool     { return l.State.StateSuccess() }
+func (l LoadBalancer) StateProgressing() bool { return l.State.StateProgressing() }
+func (l LoadBalancer) StateFailure() bool     { return l.State.StateFailure() }

--- a/pkg/apis/lbaas/v1/loadbalancer_genclient.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_genclient.go
@@ -1,13 +1,8 @@
 package v1
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"net/http"
 	"net/url"
-
-	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
 // EndpointURL returns the URL where to retrieve objects of type LoadBalancer and the identifier of the given Loadbalancer.
@@ -19,36 +14,12 @@ func (lb *LoadBalancer) EndpointURL(ctx context.Context) (*url.URL, error) {
 
 // FilterAPIRequestBody generates the request body for creating a new LoadBalancer, which differs from the LoadBalancer object.
 func (lb *LoadBalancer) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
-	op, err := types.OperationFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if op == types.OperationCreate {
-		return map[string]string{
-			"name":       lb.Name,
-			"ip_address": lb.IpAddress,
-			"state":      "2",
-		}, nil
-	}
-
-	return lb, nil
-}
-
-func (l *LoadBalancer) FilterAPIResponse(ctx context.Context, res *http.Response) (*http.Response, error) {
-	op, err := types.OperationFromContext(ctx)
-	if err != nil {
-		return res, err
-	}
-
-	if op == types.OperationDestroy {
-		err = res.Body.Close()
-		if err != nil {
-			return res, err
+	return requestBody(ctx, func() interface{} {
+		return &struct {
+			commonRequestBody
+			LoadBalancer
+		}{
+			LoadBalancer: *lb,
 		}
-
-		res.Body = io.NopCloser(bytes.NewReader([]byte("{}")))
-		return res, nil
-	}
-	return res, nil
+	})
 }

--- a/pkg/apis/lbaas/v1/loadbalancer_types.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_types.go
@@ -1,11 +1,13 @@
 package v1
 
+import "encoding/json"
+
 // anxcloud:object:hooks=RequestBodyHook,ResponseFilterHook
 
 // LoadBalancer holds the information of a load balancer instance.
 type LoadBalancer struct {
 	commonMethods
-	HasState
+	State LoadBalancerState `json:"state"`
 
 	CustomerIdentifier string     `json:"customer_identifier,omitempty"`
 	ResellerIdentifier string     `json:"reseller_identifier,omitempty"`
@@ -14,3 +16,41 @@ type LoadBalancer struct {
 	IpAddress          string     `json:"ip_address"`
 	AutomationRules    []RuleInfo `json:"automation_rules,omitempty"`
 }
+
+// LoadBalancerState is the same as State, but with different states as they are defined differently for
+// LoadBalancer resources. It still implements StateRetriever, so you can use it like the other resources.
+type LoadBalancerState struct {
+	// programatically usable enum value
+	ID string `json:"id"`
+
+	// human readable status text
+	Text string `json:"text"`
+
+	Type int `json:"type"`
+}
+
+// StateSuccess checks if the state is one of the successful ones
+func (s LoadBalancerState) StateSuccess() bool {
+	return s.ID == LoadBalancerStateOK.ID
+}
+
+// StateProgressing checks if the state is marking any change currently being applied
+func (s LoadBalancerState) StateProgressing() bool {
+	return s.ID == LoadBalancerStatePending.ID || s.ID == LoadBalancerStateCreated.ID
+}
+
+// StateFailure checks if the state is marking any failure
+func (s LoadBalancerState) StateFailure() bool {
+	return s.ID == LoadBalancerStateError.ID
+}
+
+func (s LoadBalancerState) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.ID)
+}
+
+var (
+	LoadBalancerStateOK      = LoadBalancerState{ID: "0", Text: "OK", Type: 0}
+	LoadBalancerStateError   = LoadBalancerState{ID: "1", Text: "Error", Type: 1}
+	LoadBalancerStatePending = LoadBalancerState{ID: "2", Text: "Pending", Type: 2}
+	LoadBalancerStateCreated = LoadBalancerState{ID: "3", Text: "Created", Type: 3}
+)

--- a/pkg/apis/lbaas/v1/loadbalancer_types.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_types.go
@@ -1,6 +1,6 @@
 package v1
 
-// anxcloud:object:hooks=RequestBodyHook
+// anxcloud:object:hooks=RequestBodyHook,ResponseFilterHook
 
 // LoadBalancer holds the information of a load balancer instance.
 type LoadBalancer struct {

--- a/pkg/apis/lbaas/v1/loadbalancer_types.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_types.go
@@ -6,9 +6,9 @@ package v1
 type LoadBalancer struct {
 	HasState
 
-	CustomerIdentifier string     `json:"customer_identifier"`
-	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier" anxcloud:"identifier"`
+	CustomerIdentifier string     `json:"customer_identifier,omitempty"`
+	ResellerIdentifier string     `json:"reseller_identifier,omitempty"`
+	Identifier         string     `json:"identifier,omitempty" anxcloud:"identifier"`
 	Name               string     `json:"name"`
 	IpAddress          string     `json:"ip_address"`
 	AutomationRules    []RuleInfo `json:"automation_rules,omitempty"`

--- a/pkg/apis/lbaas/v1/loadbalancer_types.go
+++ b/pkg/apis/lbaas/v1/loadbalancer_types.go
@@ -4,6 +4,7 @@ package v1
 
 // LoadBalancer holds the information of a load balancer instance.
 type LoadBalancer struct {
+	commonMethods
 	HasState
 
 	CustomerIdentifier string     `json:"customer_identifier,omitempty"`

--- a/pkg/apis/lbaas/v1/server_genclient.go
+++ b/pkg/apis/lbaas/v1/server_genclient.go
@@ -3,10 +3,11 @@ package v1
 import (
 	"bytes"
 	"context"
-	"go.anx.io/go-anxcloud/pkg/api/types"
 	"io"
 	"net/http"
 	"net/url"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
 // EndpointURL returns the URL where to retrieve objects of type Server and the identifier of the given Server.
@@ -43,25 +44,16 @@ func (s *Server) FilterAPIRequestBody(ctx context.Context) (interface{}, error) 
 		return nil, err
 	}
 
-	if op == types.OperationCreate {
+	if op == types.OperationCreate || op == types.OperationUpdate {
 		return struct {
 			Server
-			State   State  `json:"state"`
 			Backend string `json:"backend"`
-		}{
-			Server:  *s,
-			State:   NewlyCreated,
-			Backend: s.Backend.Identifier,
-		}, nil
-	} else if op == types.OperationUpdate {
-		return struct {
-			Server
-			State   State  `json:"state"`
-			Backend string `json:"backend"`
+
+			// we never want to send the state field, so making sure to omit it here
+			State string `json:"state,omitempty"`
 		}{
 			Server:  *s,
 			Backend: s.Backend.Identifier,
-			State:   Updating,
 		}, nil
 	}
 

--- a/pkg/apis/lbaas/v1/server_genclient.go
+++ b/pkg/apis/lbaas/v1/server_genclient.go
@@ -1,10 +1,7 @@
 package v1
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"net/http"
 	"net/url"
 
 	"go.anx.io/go-anxcloud/pkg/api/types"
@@ -37,43 +34,16 @@ func (s *Server) EndpointURL(ctx context.Context) (*url.URL, error) {
 	return u, nil
 }
 
-// FilterAPIRequestBody generates the request body for creating a new Server, which differs from the Server object.
+// FilterAPIRequestBody generates the request body for Servers, replacing linked Objects with just their identifier.
 func (s *Server) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
-	op, err := types.OperationFromContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if op == types.OperationCreate || op == types.OperationUpdate {
-		return struct {
+	return requestBody(ctx, func() interface{} {
+		return &struct {
+			commonRequestBody
 			Server
 			Backend string `json:"backend"`
-
-			// we never want to send the state field, so making sure to omit it here
-			State string `json:"state,omitempty"`
 		}{
 			Server:  *s,
 			Backend: s.Backend.Identifier,
-		}, nil
-	}
-
-	return s, nil
-}
-
-func (s *Server) FilterAPIResponse(ctx context.Context, res *http.Response) (*http.Response, error) {
-	op, err := types.OperationFromContext(ctx)
-	if err != nil {
-		return res, err
-	}
-
-	if op == types.OperationDestroy {
-		err = res.Body.Close()
-		if err != nil {
-			return res, err
 		}
-
-		res.Body = io.NopCloser(bytes.NewReader([]byte("{}")))
-		return res, nil
-	}
-	return res, nil
+	})
 }

--- a/pkg/apis/lbaas/v1/server_types.go
+++ b/pkg/apis/lbaas/v1/server_types.go
@@ -6,13 +6,13 @@ package v1
 type Server struct {
 	HasState
 
-	CustomerIdentifier string     `json:"customer_identifier"`
-	ResellerIdentifier string     `json:"reseller_identifier"`
-	Identifier         string     `json:"identifier" anxcloud:"identifier"`
+	CustomerIdentifier string     `json:"customer_identifier,omitempty"`
+	ResellerIdentifier string     `json:"reseller_identifier,omitempty"`
+	Identifier         string     `json:"identifier,omitempty" anxcloud:"identifier"`
 	Name               string     `json:"name"`
 	IP                 string     `json:"ip"`
 	Port               int        `json:"port"`
-	Check              string     `json:"check"`
+	Check              string     `json:"check,omitempty"`
 	AutomationRules    []RuleInfo `json:"automation_rules,omitempty"`
 
 	// Only the name and identifier fields are used and returned.

--- a/pkg/apis/lbaas/v1/server_types.go
+++ b/pkg/apis/lbaas/v1/server_types.go
@@ -4,6 +4,7 @@ package v1
 
 // Server holds the information of a load balancers backend server
 type Server struct {
+	commonMethods
 	HasState
 
 	CustomerIdentifier string     `json:"customer_identifier,omitempty"`

--- a/pkg/apis/lbaas/v1/state.go
+++ b/pkg/apis/lbaas/v1/state.go
@@ -34,6 +34,9 @@ func (s State) StateFailure() bool {
 }
 
 func (s State) MarshalJSON() ([]byte, error) {
+	// it would be great if one of the proposals in https://github.com/golang/go/issues/11939 would be
+	// accepted and we could do something like `if s.ID == "" { omitThisField }` ... but it isn't, so
+	// we have to override the field for every LBaaS Object for Create and Update operations.
 	return json.Marshal(s.ID)
 }
 

--- a/pkg/apis/lbaas/v1/xxgenerated_object_test.go
+++ b/pkg/apis/lbaas/v1/xxgenerated_object_test.go
@@ -58,13 +58,17 @@ var _ = Describe("Object Frontend", func() {
 var _ = Describe("Object LoadBalancer", func() {
 	o := LoadBalancer{}
 
-	ifaces := make([]interface{}, 0, 2)
+	ifaces := make([]interface{}, 0, 3)
 	{
 		var i types.Object
 		ifaces = append(ifaces, &i)
 	}
 	{
 		var i types.RequestBodyHook
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.ResponseFilterHook
 		ifaces = append(ifaces, &i)
 	}
 


### PR DESCRIPTION
### Description

When creating a Backend, only a certain subset of attributes was sent to the Engine.

Also improves the request body handling for all the LBaaS objects, unifying Create and Update and omitting the State attribute instead of choosing the correct one to send and adds some `omitempty` tags to Object fields.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References
* [SYSENG-1230](https://ats.anexia-it.com/browse/SYSENG-1230)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
