### PR TITLE
Prepare release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * core/v1: ResourceWithTag uses RequestBodyHook and FilterRequestURLHook instead of RequestFilterHook (#123, @marioreggiori)
 
 <!--
-Please add your release notes under the correct category (Added, Changed, ...) and use the following format as a
-guideline:
+Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 
-* <api-scope>[/<sub-api-scope] - <a short description of what changed>
+Changelog entries are best in the following format, where scope is something like "generic client" or "lbaas/v1"
+(for LBaaS API bindings). If the change isn't user-facing but still relevant enough for a changelog entry, add
+"(internal)" before the scope.
 
-e.g.
+* (internal)? scope: short description (pull request, author)
 
-* vsphere/provisioning - added progress identifier
+Some examples, more below in the actual changelog (newer entries are more likely to be good entries):
+* generic client: List resources with a channel (#42, @LittleFox94)
+* core/v1: added helper methods to tag resources (#122, @marioreggiori)
+* (internal) generic client: add hook FilterRequestURLHook (#123, @marioreggiori)
+
 -->
 
 ## [0.4.2] - 2022-03-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-* clouddns/v1: creating a Record didn't retrieve its Identifier (#120, @LittleFox94)
-* lbaas/v1: fix some attributes not being sent to the Engine when creating Backends (#135, @LittleFox94)
-
-### Added
-* generic client: FilterRequestURLHook for modifying request URLs (#123, @marioreggiori)
-
-### Changed
-* core/v1: ResourceWithTag uses RequestBodyHook and FilterRequestURLHook instead of RequestFilterHook (#123, @marioreggiori)
-
 <!--
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 
@@ -32,6 +22,18 @@ Some examples, more below in the actual changelog (newer entries are more likely
 * (internal) generic client: add hook FilterRequestURLHook (#123, @marioreggiori)
 
 -->
+
+## [0.4.3] - 2022-05-04
+
+### Fixed
+* clouddns/v1: creating a Record didn't retrieve its Identifier (#120, @LittleFox94)
+* lbaas/v1: fix some attributes not being sent to the Engine when creating Backends (#135, @LittleFox94)
+
+### Added
+* (internal) generic client: FilterRequestURLHook for modifying request URLs (#123, @marioreggiori)
+
+### Changed
+* (internal) core/v1: ResourceWithTag uses RequestBodyHook and FilterRequestURLHook instead of RequestFilterHook (#123, @marioreggiori)
 
 ## [0.4.2] - 2022-03-29
 


### PR DESCRIPTION
### Description

This updates the changelog for release 0.4.3, to be released today.

Also updates the changelog format comment, giving some fresh examples and making clear the entries are to be added below that comment - so I'll don't have to move the entries below it anymore when preparing a release.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
