### PR TITLE
compare.Reconcile: fix passing ptr arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Fixed
+* pkg/utils/object/compare.Reconcile now accepts arrays of `*struct` and `types.Object` as target/existing input (#145, @LittleFox94)
+
 ## [0.4.3] - 2022-05-04
 
 ### Fixed

--- a/pkg/utils/object/compare/reconcile.go
+++ b/pkg/utils/object/compare/reconcile.go
@@ -7,25 +7,28 @@ import (
 	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
+type reconcileObjectRetriever interface {
+	Len() int
+	Index(int) reflect.Value
+	Object(int) types.Object
+}
+
 // Reconcile fills the given arrays of Objects to create and destroy, by adding the Objects in target but not in existing to create
 // and adding the Objects in existing but not in target to destroy. Objects are compared with the Compare function in this package,
 // using the provided compareAttributes.
 //
 // Objects in target with a matching Object in existing are updated, filling e.g. the identifiers in target.
 func Reconcile(target, existing interface{}, create, destroy *[]types.Object, compareAttributes ...string) error {
-	targetArray := reflect.ValueOf(target)
-	existingArray := reflect.ValueOf(existing)
-
-	if targetArray.Kind() != reflect.Slice ||
-		existingArray.Kind() != reflect.Slice {
-		return fmt.Errorf("%w: target and existing have to be arrays", ErrInvalidType)
+	targetArray, existingArray, err := reconcileValidateInputArrays(target, existing)
+	if err != nil {
+		return err
 	}
 
 	for i := 0; i < targetArray.Len(); i++ {
 		targetElement := targetArray.Index(i)
 
 		if index, err := Search(targetElement.Interface(), existing, compareAttributes...); err == nil && index == -1 {
-			*create = append(*create, targetElement.Addr().Interface().(types.Object))
+			*create = append(*create, targetArray.Object(i))
 		} else if err != nil {
 			return fmt.Errorf("error comparing existing and target resource: %w", err)
 		} else {
@@ -38,7 +41,7 @@ func Reconcile(target, existing interface{}, create, destroy *[]types.Object, co
 		existingElement := existingArray.Index(i)
 
 		if index, err := Search(existingElement.Interface(), target, compareAttributes...); err == nil && index == -1 {
-			*destroy = append(*destroy, existingElement.Addr().Interface().(types.Object))
+			*destroy = append(*destroy, existingArray.Object(i))
 		} else if err != nil {
 			// Not reached as the same error would also have happened in the loop above already and since Search
 			// only returns the error when target contains elements, the loop above is definitely executed, too.
@@ -47,4 +50,56 @@ func Reconcile(target, existing interface{}, create, destroy *[]types.Object, co
 	}
 
 	return nil
+}
+
+func reconcileValidateInputArrays(target, existing interface{}) (targetRetriever, existingRetriever reconcileObjectRetriever, err error) {
+	targetArray := reflect.ValueOf(target)
+	existingArray := reflect.ValueOf(existing)
+
+	targetRetriever, err = reconcileValidateInputArray(targetArray)
+	if err != nil {
+		return nil, nil, fmt.Errorf("target array invalid: %w", err)
+	}
+
+	existingRetriever, err = reconcileValidateInputArray(existingArray)
+	if err != nil {
+		return nil, nil, fmt.Errorf("existing array invalid: %w", err)
+	}
+
+	return
+}
+
+func reconcileValidateInputArray(v reflect.Value) (reconcileObjectRetriever, error) {
+	if v.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("%w: target and existing have to be arrays", ErrInvalidType)
+	}
+
+	objectType := reflect.TypeOf((*types.Object)(nil)).Elem()
+	elemType := v.Type().Elem()
+
+	if !elemType.Implements(objectType) {
+		if !reflect.PtrTo(elemType).Implements(objectType) {
+			return nil, fmt.Errorf("%w: input array elements do not implement types.Object", ErrInvalidType)
+		}
+
+		return reconcileIndirectObject{v}, nil
+	}
+
+	return reconcileDirectObject{v}, nil
+}
+
+type reconcileDirectObject struct {
+	reflect.Value
+}
+
+func (rdo reconcileDirectObject) Object(i int) types.Object {
+	return rdo.Index(i).Interface().(types.Object)
+}
+
+type reconcileIndirectObject struct {
+	reflect.Value
+}
+
+func (rio reconcileIndirectObject) Object(i int) types.Object {
+	return rio.Index(i).Addr().Interface().(types.Object)
 }

--- a/pkg/utils/object/compare/reconcile_test.go
+++ b/pkg/utils/object/compare/reconcile_test.go
@@ -96,4 +96,43 @@ var _ = Describe("Reconcile", func() {
 		// -- Mara @LittleFox94 Grosch, 2022-03-28
 		Entry("invalid attribute", ErrKeyNotFound, []lbaasv1.Frontend{{}}, []lbaasv1.Frontend{{}}, "Test"),
 	)
+
+	DescribeTable("works with target being array to ...",
+		func(target interface{}, expected []types.Object) {
+			var actual []types.Object
+			err := Reconcile(target, []types.Object{}, &actual, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(ContainElements(expected))
+		},
+		Entry("structs",
+			[]lbaasv1.Frontend{
+				{Name: "foo"},
+				{Name: "bar"},
+			},
+			[]types.Object{
+				&lbaasv1.Frontend{Name: "foo"},
+				&lbaasv1.Frontend{Name: "bar"},
+			},
+		),
+		Entry("pointers to structs",
+			[]*lbaasv1.Frontend{
+				{Name: "foo"},
+				{Name: "bar"},
+			},
+			[]types.Object{
+				&lbaasv1.Frontend{Name: "foo"},
+				&lbaasv1.Frontend{Name: "bar"},
+			},
+		),
+		Entry("objects",
+			[]types.Object{
+				&lbaasv1.Frontend{Name: "foo"},
+				&lbaasv1.Frontend{Name: "bar"},
+			},
+			[]types.Object{
+				&lbaasv1.Frontend{Name: "foo"},
+				&lbaasv1.Frontend{Name: "bar"},
+			},
+		),
+	)
 })


### PR DESCRIPTION
### Description

Allow passing arrays of pointers or Objects as target/existing array to pkg/utils/object/compare.Reconcile and add the test case for this.

Quite some more changes to make CodeClimate happy again.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

* needed for https://github.com/anexia-it/k8s-anexia-ccm/pull/91

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
