### PR TITLE
Add generic vSphere Template bindings and FindNamedTemplate helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+* vsphere/v1: Template bindings and FindNamedTemplate helper added to retrieve templates by name (#148, @marioreggiori)
+
 ## [0.4.4] - 2022-06-10
 
 ### Fixed

--- a/pkg/apis/vsphere/v1/main_test.go
+++ b/pkg/apis/vsphere/v1/main_test.go
@@ -1,0 +1,13 @@
+package v1
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVSphere(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Generic vSphere API tests")
+}

--- a/pkg/apis/vsphere/v1/template_genclient.go
+++ b/pkg/apis/vsphere/v1/template_genclient.go
@@ -1,0 +1,102 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+var (
+	// ErrTemplateOperationNotSupported is returned if operations other than Get and List are performed
+	ErrTemplateOperationNotSupported = fmt.Errorf("%w: Template only supports Get and List operations", api.ErrOperationNotSupported)
+)
+
+// EndpointURL returns the URL where to retrieve objects of type Template (only Get and List operations supported)
+func (t *Template) EndpointURL(ctx context.Context) (*url.URL, error) {
+	_, err := t.operationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return url.ParseRequestURI(
+		fmt.Sprintf("/api/vsphere/v1/provisioning/templates.json/%s/%s", t.Location.Identifier, t.Type),
+	)
+}
+
+// HasPagination disables pagination for Template API (not supported by engine)
+func (t *Template) HasPagination(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
+// FilterRequestURL removes the Identifier from URL on Get operations (template needs to be parsed from list response)
+func (t *Template) FilterRequestURL(ctx context.Context, url *url.URL) (*url.URL, error) {
+	op, err := t.operationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationGet {
+		url.Path = path.Dir(url.Path)
+	}
+
+	q := url.Query()
+	q.Set("page", "1")
+	q.Set("limit", "1000")
+	url.RawQuery = q.Encode()
+
+	return url, nil
+}
+
+// DecodeAPIResponse is used to filter a single template on Get operations
+func (t *Template) DecodeAPIResponse(ctx context.Context, data io.Reader) error {
+	op, err := t.operationFromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	if op == types.OperationGet {
+		tpl, err := t.extractTemplateByID(data)
+		if err != nil {
+			return err
+		}
+		*t = *tpl
+		return nil
+	}
+
+	return json.NewDecoder(data).Decode(t)
+}
+
+func (t *Template) extractTemplateByID(data io.Reader) (*Template, error) {
+	var templates []*Template
+	err := json.NewDecoder(data).Decode(&templates)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, template := range templates {
+		if template.Identifier == t.Identifier {
+			return template, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Template with given Identifier not found in response: %w", api.ErrNotFound)
+}
+
+func (t *Template) operationFromContext(ctx context.Context) (types.Operation, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if op != types.OperationGet && op != types.OperationList {
+		return "", ErrTemplateOperationNotSupported
+	}
+
+	return op, nil
+}

--- a/pkg/apis/vsphere/v1/template_helpers.go
+++ b/pkg/apis/vsphere/v1/template_helpers.go
@@ -1,0 +1,75 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+)
+
+var (
+	// ErrTemplateNotFound is returned when the named template was not found at a given location
+	ErrTemplateNotFound = fmt.Errorf("%w: named template was not found at specified location", api.ErrNotFound)
+)
+
+const (
+	// LatestTemplateBuild is used to find the template with the highest build number
+	LatestTemplateBuild = "latest"
+)
+
+// FindNamedTemplate retrieves a template by name and build at a specified location.
+// Empty and LatestTemplateBuild build identifier will yield the highest available build.
+// It returns ErrTemplateNotFound if no matching template was found.
+func FindNamedTemplate(ctx context.Context, a api.API, name, build string, location corev1.Location) (*Template, error) {
+	var match *Template
+	buildNo := -1
+	latest := build == "" || build == LatestTemplateBuild
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var channel types.ObjectChannel
+
+	err := a.List(ctx, &Template{Type: TypeTemplate, Location: location}, api.ObjectChannel(&channel))
+	if err != nil {
+		return nil, fmt.Errorf("error listing templates: %w", err)
+	}
+
+	for res := range channel {
+		var template Template
+		err := res(&template)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving template: %w", err)
+		}
+
+		if template.Name != name {
+			continue
+		}
+
+		if latest {
+			currentTemplateBuildNo, err := template.BuildNumber()
+			if err != nil {
+				logr.FromContextOrDiscard(ctx).Info("couldn't parse build %q of template %q from location %q", template.Build, template.Identifier, location.Identifier)
+				continue
+			}
+
+			if latest && (match == nil || currentTemplateBuildNo > buildNo) {
+				match = &template
+				buildNo = currentTemplateBuildNo
+			}
+		} else if template.Build == build {
+			match = &template
+			break
+		}
+
+	}
+
+	if match == nil {
+		return nil, fmt.Errorf("%w (name: %q, build: %q, location: %q)", ErrTemplateNotFound, name, build, location.Identifier)
+	}
+
+	return match, nil
+}

--- a/pkg/apis/vsphere/v1/template_test.go
+++ b/pkg/apis/vsphere/v1/template_test.go
@@ -1,0 +1,112 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+	"go.anx.io/go-anxcloud/pkg/client"
+)
+
+var _ = Describe("Template API bindings", func() {
+	Context("BuildNumber method", func() {
+		It("can parse valid Build identifier", func() {
+			t := Template{Build: "b04"}
+			Expect(t.BuildNumber()).To(Equal(4))
+		})
+
+		DescribeTable("invalid build identifier", func(build string) {
+			t := Template{Build: build}
+			_, err := t.BuildNumber()
+			Expect(err).To(MatchError(ErrFailedToParseTemplateBuildNumber))
+		},
+			Entry("with empty build string", ""),
+			Entry("without build digits", "b"),
+			Entry("with unknown build prefix", "c123"),
+			Entry("with characters between build digits", "b1c23"),
+		)
+	})
+
+	Context("with mocked server", func() {
+		var a api.API
+		location := corev1.Location{Identifier: "mock-location-id"}
+
+		BeforeEach(func() {
+			srv := ghttp.NewServer()
+			srv.AppendHandlers(ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", fmt.Sprintf("/api/vsphere/v1/provisioning/templates.json/%s/templates", location.Identifier), "page=1&limit=1000"),
+				ghttp.RespondWithJSONEncoded(200, mockedTemplateList()),
+			))
+
+			var err error
+			a, err = api.NewAPI(api.WithClientOptions(
+				client.BaseURL(srv.URL()),
+				client.IgnoreMissingToken(),
+			))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("can List templates", func() {
+			var channel types.ObjectChannel
+			err := a.List(context.TODO(), &Template{Type: TypeTemplate, Location: location}, api.ObjectChannel(&channel))
+			Expect(err).ToNot(HaveOccurred())
+
+			templateCount := 0
+			for res := range channel {
+				t := Template{}
+				err := res(&t)
+				Expect(err).NotTo(HaveOccurred())
+				templateCount++
+			}
+			Expect(templateCount).To(Equal(10))
+		})
+
+		It("can Get templates", func() {
+			tpl := Template{Identifier: "26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0", Type: TypeTemplate, Location: location}
+			err := a.Get(context.TODO(), &tpl)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(tpl.Name).To(Equal("Flatcar Linux Stable"))
+		})
+
+		DescribeTable("find named template", func(name, build, expectedID string) {
+			template, err := FindNamedTemplate(context.TODO(), a, name, build, location)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(template.Identifier).To(Equal(expectedID))
+		},
+			Entry("latest with empty build", "Debian 11", "", "ec547552-d453-42e6-987d-51abe703c439"),
+			Entry("latest with latest build", "Flatcar Linux Stable", LatestTemplateBuild, "26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0"),
+			Entry("latest with specified build", "Flatcar Linux Stable", "b74", "26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0"),
+			Entry("not latest build", "Windows 2022", "b06", "cb16dc94-ec55-4e9a-a1a3-b76a91bbe274"),
+			Entry("with non-standard build id", "Debian 11", "possibly-valid-build-id", "9d863fd9-d0d3-4959-b226-e73192f3e43d"),
+		)
+
+		DescribeTable("find named template errors", func(name, build string) {
+			_, err := FindNamedTemplate(context.TODO(), a, name, build, location)
+			Expect(err).To(MatchError(ErrTemplateNotFound))
+		},
+			Entry("non-existing template name with build id", "FooOS 22.05", "b01"),
+			Entry("non-existing template name without build id", "FooOS 22.05", ""),
+			Entry("existing template name with non-existing build id", "Debian 11", "non-existing-build-id"),
+		)
+	})
+})
+
+func mockedTemplateList() []Template {
+	return []Template{
+		{Identifier: "e9325be9-25b9-468e-851e-56b5c0367e5a", Name: "Ubuntu 21.04", Build: "b72"},
+		{Identifier: "b21b8b77-30e3-478a-9b6d-1f61d29e9f9a", Name: "Flatcar Linux Stable", Build: "b73"},
+		{Identifier: "ec547552-d453-42e6-987d-51abe703c439", Name: "Debian 11", Build: "b18"},
+		{Identifier: "26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0", Name: "Flatcar Linux Stable", Build: "b74"},
+		{Identifier: "cb16dc94-ec55-4e9a-a1a3-b76a91bbe274", Name: "Windows 2022", Build: "b06"},
+		{Identifier: "fc3a63c6-6f4e-4193-b368-ebe9e08b4302", Name: "Debian 10", Build: "b80"},
+		{Identifier: "844ac596-5f62-4ed2-936e-b99ffe0d4f88", Name: "Flatcar Linux Stable", Build: "b72"},
+		{Identifier: "c3d4f0a6-978a-49fb-a952-7361bf531e4f", Name: "Debian 9", Build: "b92"},
+		{Identifier: "086c5f99-1be6-46ec-8374-cdc23cedd6a4", Name: "Windows 2022", Build: "b12"},
+		{Identifier: "9d863fd9-d0d3-4959-b226-e73192f3e43d", Name: "Debian 11", Build: "possibly-valid-build-id"},
+	}
+}

--- a/pkg/apis/vsphere/v1/template_types.go
+++ b/pkg/apis/vsphere/v1/template_types.go
@@ -1,0 +1,51 @@
+package v1
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+)
+
+var (
+	// ErrFailedToParseTemplateBuildNumber is returned when the template build couldn't be converted to an int
+	ErrFailedToParseTemplateBuildNumber = errors.New("failed to parse template build number")
+)
+
+// anxcloud:object:hooks=PaginationSupportHook,FilterRequestURLHook,ResponseDecodeHook
+
+// Template represents a vSphere template used for vm provisioning
+type Template struct {
+	Identifier string          `json:"id" anxcloud:"identifier"`
+	Name       string          `json:"name"`
+	Bit        string          `json:"bit"`
+	Build      string          `json:"build"`
+	Location   corev1.Location `json:"-"`
+	Type       TemplateType    `json:"-"`
+}
+
+// BuildNumber returns the parsed build number
+func (t *Template) BuildNumber() (int, error) {
+	if t.Build == "" || t.Build[0] != 'b' {
+		return 0, fmt.Errorf("%w: template build does not start with \"b\"", ErrFailedToParseTemplateBuildNumber)
+	}
+
+	buildNumber, err := strconv.Atoi(t.Build[1:])
+	if err != nil {
+		return 0, fmt.Errorf("%w: %s", ErrFailedToParseTemplateBuildNumber, err)
+	}
+
+	return buildNumber, nil
+}
+
+// TemplateType specifies the type of template
+type TemplateType string
+
+const (
+	// TypeTemplate is used for prebuilt templates
+	TypeTemplate TemplateType = "templates"
+
+	// TypeFromScratch is used for custom templates
+	TypeFromScratch TemplateType = "from_scratch"
+)

--- a/pkg/apis/vsphere/v1/xxgenerated_object_test.go
+++ b/pkg/apis/vsphere/v1/xxgenerated_object_test.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	testutils "go.anx.io/go-anxcloud/pkg/utils/test"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+var _ = Describe("Object Template", func() {
+	o := Template{}
+
+	ifaces := make([]interface{}, 0, 4)
+	{
+		var i types.Object
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.PaginationSupportHook
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.FilterRequestURLHook
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.ResponseDecodeHook
+		ifaces = append(ifaces, &i)
+	}
+
+	testutils.ObjectTests(&o, ifaces...)
+})


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Add generic vSphere Template bindings and FindNamedTemplate helper to mitigate deleted VM template (ENGSUP-5913) issues.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
