### PR TITLE
Disallow creation of DNS records with empty names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 ### Changed
 * upgraded to target Go 1.18, so now testing with Go versions 1.18 and 1.19 (#161, @LittleFox94)
+* clouddns: prevent creation of DNS records with empty names due to API change -> use "@" to target domain root instead (#168, @marioreggiori)
 
 ## [0.4.5] - 2022-08-08
 

--- a/pkg/apis/clouddns/v1/mocks_test.go
+++ b/pkg/apis/clouddns/v1/mocks_test.go
@@ -50,7 +50,7 @@ func mock_list_zones(zone string, times randomTimes) {
 					{},
 					{Records: []Record{}},
 					{Records: []Record{
-						{Name: "", Type: "A", RData: "127.0.0.2"},
+						{Name: "@", Type: "A", RData: "127.0.0.2"},
 					}},
 					{}, {},
 				},
@@ -66,8 +66,8 @@ func mock_list_zones(zone string, times randomTimes) {
 				Revisions: []Revision{
 					{}, {},
 					{Records: []Record{
-						{Name: "", Type: "A", RData: "127.0.0.1"},
-						{Name: "", Type: "AAAA", RData: "::1"},
+						{Name: "@", Type: "A", RData: "127.0.0.1"},
+						{Name: "@", Type: "AAAA", RData: "::1"},
 						{Name: "www", Type: "A", RData: "127.0.0.1"},
 						{Name: "www", Type: "AAAA", RData: "::1"},
 						{Name: "test1", Type: "TXT", RData: "\"test record\""},
@@ -107,8 +107,8 @@ func mock_get_zone(zone string, times randomTimes, updated bool) {
 			Revisions: []Revision{
 				{}, {},
 				{Records: []Record{
-					{Name: "", Type: "A", RData: "127.0.0.1"},
-					{Name: "", Type: "AAAA", RData: "::1"},
+					{Name: "@", Type: "A", RData: "127.0.0.1"},
+					{Name: "@", Type: "AAAA", RData: "::1"},
 					{Name: "www", Type: "A", RData: "127.0.0.1"},
 					{Name: "www", Type: "AAAA", RData: "::1"},
 					{Name: "test1", Type: "TXT", RData: "\"test record\""},
@@ -185,8 +185,8 @@ func mock_list_records(zone string) {
 	mock.server.AppendHandlers(ghttp.CombineHandlers(
 		ghttp.VerifyRequest("GET", fmt.Sprintf("/api/clouddns/v1/zone.json/%s/records", zone)),
 		ghttp.RespondWithJSONEncoded(200, []Record{
-			{Name: "", Type: "A", RData: "127.0.0.1"},
-			{Name: "", Type: "AAAA", RData: "::1"},
+			{Name: "@", Type: "A", RData: "127.0.0.1"},
+			{Name: "@", Type: "AAAA", RData: "::1"},
 			{Name: "www", Type: "A", RData: "127.0.0.1"},
 			{Name: "www", Type: "AAAA", RData: "::1"},
 			{Name: "test1", Type: "TXT", RData: "\"test record\""},
@@ -216,7 +216,7 @@ func mock_search_records_by_rdata(zone string, rdata string) {
 	mock.server.AppendHandlers(ghttp.CombineHandlers(
 		ghttp.VerifyRequest("GET", fmt.Sprintf("/api/clouddns/v1/zone.json/%s/records", zone)),
 		ghttp.RespondWithJSONEncoded(200, []Record{
-			{Name: "", Type: "AAAA", RData: rdata},
+			{Name: "@", Type: "AAAA", RData: rdata},
 			{Name: "www", Type: "AAAA", RData: rdata},
 		}),
 	))

--- a/pkg/apis/clouddns/v1/record_types.go
+++ b/pkg/apis/clouddns/v1/record_types.go
@@ -1,14 +1,16 @@
 package v1
 
-// anxcloud:object:hooks=ResponseDecodeHook,PaginationSupportHook
+// anxcloud:object:hooks=ResponseDecodeHook,PaginationSupportHook,RequestFilterHook
 
 type Record struct {
 	Identifier string `json:"identifier,omitempty" anxcloud:"identifier"`
 	ZoneName   string `json:"-"`
 	Immutable  bool   `json:"immutable,omitempty"`
-	Name       string `json:"name"`
-	RData      string `json:"rdata"`
-	Region     string `json:"region"`
-	TTL        int    `json:"ttl"`
-	Type       string `json:"type"`
+	// Name of the DNS record.
+	// Use "@" to select the domain root. Creation of records with an empty Name field is not supported.
+	Name   string `json:"name"`
+	RData  string `json:"rdata"`
+	Region string `json:"region"`
+	TTL    int    `json:"ttl"`
+	Type   string `json:"type"`
 }

--- a/pkg/apis/clouddns/v1/xxgenerated_object_test.go
+++ b/pkg/apis/clouddns/v1/xxgenerated_object_test.go
@@ -12,7 +12,7 @@ import (
 var _ = Describe("Object Record", func() {
 	o := Record{}
 
-	ifaces := make([]interface{}, 0, 3)
+	ifaces := make([]interface{}, 0, 4)
 	{
 		var i types.Object
 		ifaces = append(ifaces, &i)
@@ -23,6 +23,10 @@ var _ = Describe("Object Record", func() {
 	}
 	{
 		var i types.PaginationSupportHook
+		ifaces = append(ifaces, &i)
+	}
+	{
+		var i types.RequestFilterHook
 		ifaces = append(ifaces, &i)
 	}
 

--- a/pkg/clouddns/zone/mocks_test.go
+++ b/pkg/clouddns/zone/mocks_test.go
@@ -67,8 +67,8 @@ func mock_list_zones(zone string, times randomTimes) {
 					Revisions: []Revision{
 						{}, {},
 						{Records: []Record{
-							{Name: "", Type: "A", RData: "127.0.0.1"},
-							{Name: "", Type: "AAAA", RData: "::1"},
+							{Name: "@", Type: "A", RData: "127.0.0.1"},
+							{Name: "@", Type: "AAAA", RData: "::1"},
 							{Name: "www", Type: "A", RData: "127.0.0.1"},
 							{Name: "www", Type: "AAAA", RData: "::1"},
 							{Name: "test1", Type: "TXT", RData: "\"test record\""},
@@ -100,8 +100,8 @@ func mock_get_zone(zone string, times randomTimes) {
 			Revisions: []Revision{
 				{}, {},
 				{Records: []Record{
-					{Name: "", Type: "A", RData: "127.0.0.1"},
-					{Name: "", Type: "AAAA", RData: "::1"},
+					{Name: "@", Type: "A", RData: "127.0.0.1"},
+					{Name: "@", Type: "AAAA", RData: "::1"},
 					{Name: "www", Type: "A", RData: "127.0.0.1"},
 					{Name: "www", Type: "AAAA", RData: "::1"},
 					{Name: "test1", Type: "TXT", RData: "\"test record\""},
@@ -199,8 +199,8 @@ func mock_list_records(zone string) {
 	mock.server.AppendHandlers(ghttp.CombineHandlers(
 		ghttp.VerifyRequest("GET", fmt.Sprintf("/api/clouddns/v1/zone.json/%s/records", zone)),
 		ghttp.RespondWithJSONEncoded(200, []Record{
-			{Name: "", Type: "A", RData: "127.0.0.1"},
-			{Name: "", Type: "AAAA", RData: "::1"},
+			{Name: "@", Type: "A", RData: "127.0.0.1"},
+			{Name: "@", Type: "AAAA", RData: "::1"},
 			{Name: "www", Type: "A", RData: "127.0.0.1"},
 			{Name: "www", Type: "AAAA", RData: "::1"},
 			{Name: "test1", Type: "TXT", RData: "\"test record\""},


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Due to changes of a default value in the CloudDNS API (record name) we decided to disallow the creation of DNS records with an empty name parameter. Use `"@"` as name instead to target the root domain.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
