### PR TITLE
disable integration tests for pull requests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   repository_dispatch:
     types: [ok-to-test-command]
 


### PR DESCRIPTION
### Description

Our integration tests often fail due to changes in other systems, making them a bad tool to recognize if a PR is safe to merge. To reduce unnecessary load on our systems, we disable integration tests for pull request - due to the fact in the first sentence, we don't look at the "Failed" result anyway.

We should definitely revise this in the future, enabling some integration tests matching the changes in the PR (e.g. re-run `pkg/apis/lbaas/v1` integration tests when something was changed below that).

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
