### PR TITLE
Extend Kubernetes Cluster bindings to include prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Some examples, more below in the actual changelog (newer entries are more likely
 ### Fixed
 * trace logging in pkg/client now really includes the request/response bodies (#211, @LittleFox94)
 
+### Added
+* kubernetes/v1: configurable cluster prefixes (#208, @marioreggiori)
+* generic client: common resource types (#208, @marioreggiori)
+
 ## [0.5.0] - 2022-11-30
 
 ### Added

--- a/pkg/apis/common/gs/resource.go
+++ b/pkg/apis/common/gs/resource.go
@@ -1,0 +1,21 @@
+package gs
+
+import (
+	"encoding/json"
+	"strings"
+
+	"go.anx.io/go-anxcloud/pkg/apis/common"
+)
+
+// PartialResourceList represents a linked resource list in GS
+type PartialResourceList []common.PartialResource
+
+// MarshalJSON unfolds the resources to their identifier as a comma-separated string
+func (prl PartialResourceList) MarshalJSON() ([]byte, error) {
+	resourceIdentifiers := make([]string, 0, len(prl))
+	for _, pr := range prl {
+		resourceIdentifiers = append(resourceIdentifiers, pr.Identifier)
+	}
+
+	return json.Marshal(strings.Join(resourceIdentifiers, ","))
+}

--- a/pkg/apis/common/gs/resource_test.go
+++ b/pkg/apis/common/gs/resource_test.go
@@ -1,0 +1,26 @@
+package gs
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommonGenericServiceAPIResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "test suite for common gs API resources")
+}
+
+var _ = DescribeTable("PartialResourceList",
+	func(list PartialResourceList, expected string) {
+		data, err := json.Marshal(&list)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).To(Equal(expected))
+	},
+	Entry("empty list", PartialResourceList{}, `""`),
+	Entry("single resource", PartialResourceList{{Identifier: "foo"}}, `"foo"`),
+	Entry("multiple resources", PartialResourceList{{Identifier: "foo"}, {Identifier: "bar"}}, `"foo,bar"`),
+)

--- a/pkg/apis/common/resource.go
+++ b/pkg/apis/common/resource.go
@@ -1,0 +1,16 @@
+package common
+
+import (
+	"encoding/json"
+)
+
+// PartialResource represents a linked resource
+type PartialResource struct {
+	Identifier string `json:"identifier,omitempty"`
+	Name       string `json:"name,omitempty"`
+}
+
+// MarshalJSON unfolds the resource to its identifier
+func (pr PartialResource) MarshalJSON() ([]byte, error) {
+	return json.Marshal(pr.Identifier)
+}

--- a/pkg/apis/common/resource_test.go
+++ b/pkg/apis/common/resource_test.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommonAPIResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "test suite for common API resources")
+}
+
+var _ = Describe("PartialResource", func() {
+	It("json marshalls to the resources identifier", func() {
+		pr := PartialResource{Identifier: "foo", Name: "bar"}
+		data, err := json.Marshal(&pr)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).To(Equal(`"foo"`))
+	})
+})

--- a/pkg/apis/kubernetes/v1/cluster_genclient.go
+++ b/pkg/apis/kubernetes/v1/cluster_genclient.go
@@ -2,16 +2,51 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"net/url"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/utils/pointer"
 )
+
+// ErrManagedPrefixSet is returned if a prefix is both set to managed and also set
+// to an existing prefix on create
+var ErrManagedPrefixSet = errors.New("managed prefixes cannot be set on create")
 
 // EndpointURL returns the common URL for operations on Cluster resource
 func (c *Cluster) EndpointURL(ctx context.Context) (*url.URL, error) {
 	return endpointURL(ctx, c, "/api/kubernetes/v1/cluster.json")
 }
 
+// explicitlyFalse returns true if the value of the provided
+// bool pointer is set to false, nil and true pointer return false
+func explicitlyFalse(b *bool) bool {
+	return b != nil && !pointer.BoolVal(b)
+}
+
+// prefixConfigurationValidCreate validates that prefixes configured as managed
+// are not set. This is only relevant for `Create` operations.
+func prefixConfigurationValidCreate(c *Cluster) bool {
+	var (
+		internalV4 = c.InternalIPv4Prefix == nil || explicitlyFalse(c.ManageInternalIPv4Prefix)
+		externalV4 = c.ExternalIPv4Prefix == nil || explicitlyFalse(c.ManageExternalIPv4Prefix)
+		externalV6 = c.ExternalIPv6Prefix == nil || explicitlyFalse(c.ManageExternalIPv6Prefix)
+	)
+
+	return internalV4 && externalV4 && externalV6
+}
+
 // FilterAPIRequestBody adds the CommonRequestBody
 func (c *Cluster) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
+	op, err := types.OperationFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if op == types.OperationCreate && !prefixConfigurationValidCreate(c) {
+		return nil, ErrManagedPrefixSet
+	}
+
 	return requestBody(ctx, func() interface{} {
 		return &struct {
 			commonRequestBody

--- a/pkg/apis/kubernetes/v1/cluster_test.go
+++ b/pkg/apis/kubernetes/v1/cluster_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/onsi/gomega/ghttp"
 	"go.anx.io/go-anxcloud/pkg/api"
 	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/apis/common"
 	"go.anx.io/go-anxcloud/pkg/apis/common/gs"
 	"go.anx.io/go-anxcloud/pkg/client"
+	"go.anx.io/go-anxcloud/pkg/utils/pointer"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -65,3 +67,35 @@ var _ = Describe("AwaitCompletion", Ordered, func() {
 		Expect(err).To(MatchError(context.DeadlineExceeded))
 	})
 })
+
+var _ = Describe("Create Cluster", func() {
+	DescribeTable("prefix configurations", func(cluster Cluster, expected error) {
+		_, err := cluster.FilterAPIRequestBody(types.ContextWithOperation(context.TODO(), types.OperationCreate))
+		if expected == nil {
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(MatchError(expected))
+		}
+	},
+		Entry("all prefixes implicitly managed", Cluster{}, nil),
+		Entry("all prefixes explicitly managed", Cluster{ManageInternalIPv4Prefix: pointer.Bool(true), ManageExternalIPv4Prefix: pointer.Bool(true), ManageExternalIPv6Prefix: pointer.Bool(true)}, nil),
+		Entry("internal v4 prefix implicitly managed and explicitly provided", Cluster{InternalIPv4Prefix: &common.PartialResource{Identifier: "foo"}}, ErrManagedPrefixSet),
+		Entry("internal v4 prefix explicitly managed and explicitly provided", Cluster{ManageInternalIPv4Prefix: pointer.Bool(true), InternalIPv4Prefix: &common.PartialResource{Identifier: "foo"}}, ErrManagedPrefixSet),
+		Entry("internal v4 prefix explicitly unmanaged and provided", Cluster{ManageInternalIPv4Prefix: pointer.Bool(false), InternalIPv4Prefix: &common.PartialResource{Identifier: "foo"}}, nil),
+		Entry("external v4 prefix implicitly managed and explicitly provided", Cluster{ExternalIPv4Prefix: &common.PartialResource{Identifier: "foo"}}, ErrManagedPrefixSet),
+		Entry("external v4 prefix explicitly managed and explicitly provided", Cluster{ManageExternalIPv4Prefix: pointer.Bool(true), ExternalIPv4Prefix: &common.PartialResource{Identifier: "foo"}}, ErrManagedPrefixSet),
+		Entry("external v4 prefix explicitly unmanaged and provided", Cluster{ManageExternalIPv4Prefix: pointer.Bool(false), ExternalIPv4Prefix: &common.PartialResource{Identifier: "foo"}}, nil),
+		Entry("external v6 prefix implicitly managed and explicitly provided", Cluster{ExternalIPv6Prefix: &common.PartialResource{Identifier: "foo"}}, ErrManagedPrefixSet),
+		Entry("external v6 prefix explicitly managed and explicitly provided", Cluster{ManageExternalIPv6Prefix: pointer.Bool(true), ExternalIPv6Prefix: &common.PartialResource{Identifier: "foo"}}, ErrManagedPrefixSet),
+		Entry("external v6 prefix explicitly unmanaged and provided", Cluster{ManageExternalIPv6Prefix: pointer.Bool(false), ExternalIPv6Prefix: &common.PartialResource{Identifier: "foo"}}, nil),
+	)
+})
+
+var _ = DescribeTable("explicitlyFalse",
+	func(b *bool, expected bool) {
+		Expect(explicitlyFalse(b)).To(Equal(expected))
+	},
+	Entry("explicitly false", pointer.Bool(false), true),
+	Entry("explicitly true", pointer.Bool(true), false),
+	Entry("implicitly false (nil)", nil, false),
+)

--- a/pkg/apis/kubernetes/v1/cluster_types.go
+++ b/pkg/apis/kubernetes/v1/cluster_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"go.anx.io/go-anxcloud/pkg/apis/common"
 	"go.anx.io/go-anxcloud/pkg/apis/common/gs"
 	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
 )
@@ -30,6 +31,29 @@ type Cluster struct {
 	// If enabled, Service VMs are set up as LBaaS hosts enabling K8s services of type LoadBalancer.
 	// Requires Service VMs.
 	EnableLBaaS *bool `json:"enable_lbaas,omitempty"`
+
+	// Identifier of an internal v4 prefix (to be) assigned to the cluster. If ManageInternalIPv4Prefix
+	// is set to false, the Prefix given in this field is used when creating the cluster, otherwise a new
+	// prefix will be created automatically. The API will always return the Prefix for the Cluster,
+	// when ManageInternalIPv4Prefix is true, this will be the Prefix that was created automatically.
+	InternalIPv4Prefix *common.PartialResource `json:"internal_ipv4_prefix,omitempty"`
+	// Identifier of an external v4 prefix (to be) assigned to the cluster. If ManageExternalIPv4Prefix
+	// is set to false, the Prefix given in this field is used when creating the cluster, otherwise a new
+	// prefix will be created automatically. The API will always return the Prefix for the Cluster,
+	// when ManageExternalIPv4Prefix is true, this will be the Prefix that was created automatically.
+	ExternalIPv4Prefix *common.PartialResource `json:"external_ipv4_prefix,omitempty"`
+	// Identifier of an external v6 prefix (to be) assigned to the cluster. If ManageExternalIPv6Prefix
+	// is set to false, the Prefix given in this field is used when creating the cluster, otherwise a new
+	// prefix will be created automatically. The API will always return the Prefix for the Cluster,
+	// when ManageExternalIPv6Prefix is true, this will be the Prefix that was created automatically.
+	ExternalIPv6Prefix *common.PartialResource `json:"external_ipv6_prefix,omitempty"`
+
+	// If set to true an internal v4 prefix is automatically created for the cluster. Defaults to true if not set.
+	ManageInternalIPv4Prefix *bool `json:"manage_internal_ipv4_prefix,omitempty"`
+	// If set to true an external v4 prefix is automatically created for the cluster. Defaults to true if not set.
+	ManageExternalIPv4Prefix *bool `json:"manage_external_ipv4_prefix,omitempty"`
+	// If set to true an external v6 prefix is automatically created for the cluster. Defaults to true if not set.
+	ManageExternalIPv6Prefix *bool `json:"manage_external_ipv6_prefix,omitempty"`
 
 	// Contains a kubeconfig if available
 	KubeConfig *string `json:"kubeconfig,omitempty"`


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
This PR adds fields to the Kubernetes cluster API resource which allow configurable prefixes. It also adds common resource types to work with generic services.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
