### PR TITLE
pkg/client: fix trace logging request/response bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Fixed
+* trace logging in pkg/client now really includes the request/response bodies (#211, @LittleFox94)
+
 ## [0.5.0] - 2022-11-30
 
 ### Added

--- a/pkg/client/log_utils.go
+++ b/pkg/client/log_utils.go
@@ -53,7 +53,7 @@ func logRequest(req *http.Request, logger logr.Logger) {
 	headers.Set("Authorization", "REDACTED")
 
 	if body := stringifyBody(&req.Body, logger); body != nil {
-		log = log.WithValues("body", body)
+		log = log.WithValues("body", *body)
 	}
 
 	log.Info("Sending request to Engine",
@@ -74,7 +74,7 @@ func logResponse(res *http.Response, logger logr.Logger) {
 	headers.Set("Set-Cookie", "REDACTED")
 
 	if body := stringifyBody(&res.Body, logger); body != nil {
-		log = log.WithValues("body", body)
+		log = log.WithValues("body", *body)
 	}
 
 	if res.Request != nil {


### PR DESCRIPTION
### Description

Client trace logging (requests and responses) was broken, logging only the pointer to the request/response body instead of the contents. This PR fixes that.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
