### PR TITLE
pkg/client: trace log to logger attached to request context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Changed
+* trace logging in pkg/client now goes to a logr.Logger attached to the request context, falling back to the logger configured on the client (#212, @LittleFox94)
+
 ### Fixed
 * trace logging in pkg/client now really includes the request/response bodies (#211, @LittleFox94)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -248,7 +248,12 @@ func (c client) Do(req *http.Request) (*http.Response, error) {
 }
 
 func (c client) handleRequest(req *http.Request) (*http.Response, error) {
-	logRequest(req, c.logger)
+	logger := c.logger
+	if l, err := logr.FromContext(req.Context()); err == nil {
+		logger = l
+	}
+
+	logRequest(req, logger)
 
 	client := c.httpClient
 
@@ -269,7 +274,7 @@ func (c client) handleRequest(req *http.Request) (*http.Response, error) {
 		return response, err
 	}
 
-	logResponse(response, c.logger)
+	logResponse(response, logger)
 
 	return response, err
 }


### PR DESCRIPTION
### Description

Instead of sending all trace logs to one logger configured on the client, we instead send it to the logr.Logger attached to the request context and fallback to the client logger.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
