### PR TITLE
Fix most integration tests after #227 broke them

### DIFF
--- a/pkg/api/e2e_test.go
+++ b/pkg/api/e2e_test.go
@@ -25,6 +25,8 @@ const (
 )
 
 var _ = Describe("options", func() {
+	testutils.Seed(GinkgoRandomSeed())
+
 	var a api.API
 
 	BeforeEach(func() {

--- a/pkg/apis/clouddns/v1/main_test.go
+++ b/pkg/apis/clouddns/v1/main_test.go
@@ -33,9 +33,4 @@ func TestCloudDNS(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CloudDNS tests")
-
-	a, _ := getApi()
-	if err := cleanupZones(a); err != nil {
-		t.Fatal(err)
-	}
 }

--- a/pkg/apis/clouddns/v1/mocks_test.go
+++ b/pkg/apis/clouddns/v1/mocks_test.go
@@ -14,7 +14,8 @@ import (
 var mock *mockserver
 
 type mockserver struct {
-	server *ghttp.Server
+	server              *ghttp.Server
+	numRequestsToIgnore int
 }
 
 func initMockServer() {
@@ -26,7 +27,9 @@ func initMockServer() {
 // nolint:golint,unparam
 func mock_expect_request_count(count int) {
 	if mock != nil {
-		Expect(mock.server.ReceivedRequests()).Should(HaveLen(count))
+		Expect(mock.server.ReceivedRequests()).Should(HaveLen(count + mock.numRequestsToIgnore))
+
+		mock.numRequestsToIgnore += count
 	}
 }
 
@@ -191,6 +194,8 @@ func mock_list_records(zone string) {
 			{Name: "www", Type: "A", RData: "127.0.0.1"},
 			{Name: "www", Type: "AAAA", RData: "::1"},
 			{Name: "test1", Type: "TXT", RData: "\"test record\""},
+			{Name: "test2", Type: "TXT", RData: "\"test record\""},
+			{Name: "test3", Type: "TXT", RData: "\"test record\""},
 		}),
 	))
 }
@@ -232,6 +237,8 @@ func mock_search_records_by_type(zone string, t string) {
 		ghttp.VerifyRequest("GET", fmt.Sprintf("/api/clouddns/v1/zone.json/%s/records", zone)),
 		ghttp.RespondWithJSONEncoded(200, []clouddnsv1.Record{
 			{Name: "test1", Type: t, RData: "\"test record\""},
+			{Name: "test2", Type: "TXT", RData: "\"test record\""},
+			{Name: "test3", Type: "TXT", RData: "\"test record\""},
 		}),
 	))
 }

--- a/pkg/apis/clouddns/v1/zone_test.go
+++ b/pkg/apis/clouddns/v1/zone_test.go
@@ -26,32 +26,7 @@ type randomTimes struct {
 	ttl     int
 }
 
-var createdZones = make([]string, 0)
-
-func ensureTestZone(api api.API, name string, times randomTimes) {
-	if !isIntegrationTest {
-		return
-	}
-
-	zone := clouddnsv1.Zone{
-		Name:       name,
-		IsMaster:   true,
-		DNSSecMode: "unvalidated",
-		AdminEmail: "admin@" + name,
-		Refresh:    times.refresh,
-		Retry:      times.retry,
-		Expire:     times.expire,
-		TTL:        times.ttl,
-	}
-
-	err := api.Create(context.TODO(), &zone)
-
-	Expect(err).NotTo(HaveOccurred())
-
-	createdZones = append(createdZones, name)
-}
-
-func cleanupZones(a api.API) error {
+func cleanupZone(a api.API, zone string) error {
 	if !isIntegrationTest {
 		return nil
 	}
@@ -59,44 +34,29 @@ func cleanupZones(a api.API) error {
 	retryAllowance := 5
 	retryTime := 5 * time.Second
 
-	for len(createdZones) > 0 {
-		notDone := make([]string, 0, len(createdZones))
-		lastTryErrors := make([]error, 0, len(createdZones))
-
-		for _, zoneName := range createdZones {
-			err := a.Destroy(context.TODO(), &clouddnsv1.Zone{Name: zoneName})
-
-			if err != nil {
-				re := api.HTTPError{}
-				if isResponseError := errors.As(err, &re); !isResponseError || re.StatusCode() != 404 {
-					notDone = append(notDone, zoneName)
-					lastTryErrors = append(lastTryErrors, err)
-				}
-			}
+	for {
+		err := a.Destroy(context.TODO(), &clouddnsv1.Zone{Name: zone})
+		if err == nil {
+			return nil
 		}
 
-		createdZones = notDone
+		re := api.HTTPError{}
+		if isResponseError := errors.As(err, &re); isResponseError && re.StatusCode() == 404 {
+			return nil
+		}
+
+		// Deleting the zone failed. Retry up to "initial value of retryAllowance" times,
+		// sleeping retryTime between each retry, with retryTime being doubled after each try.
 		retryAllowance--
 
-		// Deleting of at least one zone failed. Retry up to "initial value of retryAllowance" times,
-		// sleeping retryTime between each retry, with retryTime being doubled after each try.
-		if len(notDone) > 0 {
-			if retryAllowance >= 0 {
-				time.Sleep(retryTime)
+		if retryAllowance >= 0 {
+			time.Sleep(retryTime)
 
-				retryTime = retryTime * 2
-			} else {
-				messages := make([]string, 0, len(lastTryErrors))
-				for _, err := range lastTryErrors {
-					messages = append(messages, err.Error())
-				}
-
-				return fmt.Errorf("Error deleting the zones created for this request, remaining zones are %+v and last errors were %+v", notDone, messages)
-			}
+			retryTime = retryTime * 2
+		} else {
+			return fmt.Errorf("Error deleting the zone created for this test, delete zone %+v manually (last error was %+v)", zone, err)
 		}
 	}
-
-	return nil
 }
 
 func ensureTestRecord(a api.API, record clouddnsv1.Record) string {
@@ -131,13 +91,13 @@ func ensureTestRecord(a api.API, record clouddnsv1.Record) string {
 	return uuid.Nil.String()
 }
 
-var _ = Describe("CloudDNS API client", func() {
+var _ = Describe("CloudDNS API client", Ordered, func() {
 	var zoneName string
 	var times randomTimes
 	var a api.API
 
-	BeforeEach(func() {
-		zoneName = test.RandomHostname() + ".go-anxcloud.test"
+	BeforeAll(func() {
+		zoneName = test.RandomHostname() + "-genclient.go-anxcloud.test"
 
 		rng := rand.New(rand.NewSource(GinkgoRandomSeed()))
 
@@ -149,6 +109,14 @@ var _ = Describe("CloudDNS API client", func() {
 			rng.Intn(10) * 1000,
 			rng.Intn(10) * 100,
 		}
+
+		DeferCleanup(func() {
+			if zoneName != "" {
+				if err := cleanupZone(a, zoneName); err != nil {
+					GinkgoLogr.Error(err, "Error deleting zone")
+				}
+			}
+		})
 	})
 
 	Context("without the zone existing", func() {
@@ -174,16 +142,10 @@ var _ = Describe("CloudDNS API client", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			mock_expect_request_count(1)
-
-			createdZones = append(createdZones, zoneName)
 		})
 	})
 
 	Context("with the zone existing", func() {
-		JustBeforeEach(func() {
-			ensureTestZone(a, zoneName, times)
-		})
-
 		CheckZoneData := func(zone clouddnsv1.Zone) {
 			Expect(zone.AdminEmail).To(Equal("admin@" + zoneName))
 			Expect(zone.Refresh).To(Equal(times.refresh))
@@ -260,20 +222,6 @@ var _ = Describe("CloudDNS API client", func() {
 			mock_expect_request_count(2)
 		})
 
-		It("should make a valid delete zone request", func() {
-			mock_delete_zone(zoneName)
-
-			ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
-			defer cancel()
-
-			zone := clouddnsv1.Zone{Name: zoneName}
-			err := a.Destroy(ctx, &zone)
-
-			Expect(err).NotTo(HaveOccurred())
-
-			mock_expect_request_count(1)
-		})
-
 		It("should make a valid create record request", func() {
 			record := clouddnsv1.Record{
 				Name:     "test1",
@@ -307,8 +255,6 @@ var _ = Describe("CloudDNS API client", func() {
 				TTL:      300,
 			}
 
-			mock_create_record(zoneName, record)
-
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
@@ -317,223 +263,246 @@ var _ = Describe("CloudDNS API client", func() {
 
 			mock_expect_request_count(0)
 		})
-	})
 
-	Context("with the record already existing", func() {
-		var identifier string
+		Context("with the record already existing", Ordered, func() {
+			var identifier string
 
-		JustBeforeEach(func() {
-			ensureTestZone(a, zoneName, times)
-			identifier = ensureTestRecord(a, clouddnsv1.Record{
-				Name:     "test1",
-				ZoneName: zoneName,
-				Type:     "TXT",
-				RData:    "test record",
-				Region:   "default",
-				TTL:      300,
+			BeforeEach(func() {
+				record := clouddnsv1.Record{
+					Name:     "test2",
+					ZoneName: zoneName,
+					Type:     "TXT",
+					RData:    "test record",
+					Region:   "default",
+					TTL:      300,
+				}
+
+				identifier = ensureTestRecord(a, record)
+			})
+
+			It("should make a valid delete record request", func() {
+				mock_delete_record(zoneName, identifier)
+
+				ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
+				defer cancel()
+				err := a.Destroy(ctx, &clouddnsv1.Record{Identifier: identifier, ZoneName: zoneName})
+				Expect(err).NotTo(HaveOccurred())
+
+				mock_expect_request_count(1)
+			})
+
+			// Have the update test after the delete test in our Ordered
+			// context to ensure we don't have a record with the given name
+			// anymore when creating it for this test and without having to
+			// find the identifier of the record after it was updated to then
+			// delete it.
+			It("should make a valid update record request", func() {
+				record := clouddnsv1.Record{
+					Identifier: identifier,
+					Name:       "test2",
+					ZoneName:   zoneName,
+					Type:       "TXT",
+					RData:      "test record",
+					Region:     "default",
+					TTL:        300,
+				}
+
+				mock_update_record(zoneName, identifier, record)
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+
+				err := a.Update(ctx, &record)
+				Expect(err).NotTo(HaveOccurred())
+
+				mock_expect_request_count(1)
 			})
 		})
 
-		It("should make a valid update record request", func() {
-			record := clouddnsv1.Record{
-				Identifier: identifier,
-				Name:       "test1",
-				ZoneName:   zoneName,
-				Type:       "TXT",
-				RData:      "test record",
-				Region:     "default",
-				TTL:        300,
-			}
+		Context("with some records existing", Ordered, func() {
+			BeforeAll(func() {
+				_ = ensureTestRecord(a, clouddnsv1.Record{
+					Name:     "test3",
+					ZoneName: zoneName,
+					Type:     "TXT",
+					RData:    "test record",
+					Region:   "default",
+					TTL:      300,
+				})
 
-			mock_update_record(zoneName, identifier, record)
+				_ = ensureTestRecord(a, clouddnsv1.Record{
+					Name:     "@",
+					ZoneName: zoneName,
+					Type:     "A",
+					RData:    "127.0.0.1",
+					Region:   "default",
+					TTL:      300,
+				})
 
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
+				_ = ensureTestRecord(a, clouddnsv1.Record{
+					Name:     "@",
+					ZoneName: zoneName,
+					Type:     "AAAA",
+					RData:    "::1",
+					Region:   "default",
+					TTL:      300,
+				})
 
-			err := a.Update(ctx, &record)
-			Expect(err).NotTo(HaveOccurred())
+				_ = ensureTestRecord(a, clouddnsv1.Record{
+					Name:     "www",
+					ZoneName: zoneName,
+					Type:     "A",
+					RData:    "127.0.0.1",
+					Region:   "default",
+					TTL:      300,
+				})
 
-			mock_expect_request_count(1)
+				_ = ensureTestRecord(a, clouddnsv1.Record{
+					Name:     "www",
+					ZoneName: zoneName,
+					Type:     "AAAA",
+					RData:    "::1",
+					Region:   "default",
+					TTL:      300,
+				})
+			})
+
+			It("lists all records of the zone", func() {
+				mock_list_records(zoneName)
+
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+
+				channel := make(types.ObjectChannel)
+				err := a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName}, api.ObjectChannel(&channel))
+				Expect(err).NotTo(HaveOccurred())
+
+				r := clouddnsv1.Record{}
+				rmap := make(map[string]map[string]clouddnsv1.Record, 3)
+				for res := range channel {
+					err := res(&r)
+					Expect(err).NotTo(HaveOccurred())
+					if _, ok := rmap[r.Name]; !ok {
+						rmap[r.Name] = make(map[string]clouddnsv1.Record, 2)
+					}
+
+					rmap[r.Name][r.Type] = r
+				}
+
+				Expect(rmap).To(HaveKey("@"))
+				Expect(rmap).To(HaveKey("www"))
+				Expect(rmap).To(HaveKey("test3"))
+
+				Expect(rmap["@"]).To(HaveKey("A"))
+				Expect(rmap["@"]).To(HaveKey("AAAA"))
+				Expect(rmap["www"]).To(HaveKey("A"))
+				Expect(rmap["www"]).To(HaveKey("AAAA"))
+				Expect(rmap["test3"]).To(HaveKey("TXT"))
+
+				Expect(rmap["@"]["A"].RData).To(Equal("127.0.0.1"))
+				Expect(rmap["www"]["A"].RData).To(Equal("127.0.0.1"))
+				Expect(rmap["@"]["AAAA"].RData).To(Equal("::1"))
+				Expect(rmap["www"]["AAAA"].RData).To(Equal("::1"))
+
+				Expect(rmap["test3"]["TXT"].RData).To(Equal("\"test record\"")) // I love the engine. Mara @LittleFox94 Grosch
+
+				Expect(rmap["@"]["A"].ZoneName).To(Equal(zoneName))
+				Expect(rmap["www"]["A"].ZoneName).To(Equal(zoneName))
+				Expect(rmap["@"]["AAAA"].ZoneName).To(Equal(zoneName))
+				Expect(rmap["www"]["AAAA"].ZoneName).To(Equal(zoneName))
+
+				Expect(rmap["test3"]["TXT"].ZoneName).To(Equal(zoneName))
+
+				mock_expect_request_count(1)
+			})
+
+			It("searches for and finds specific records in the zone", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+				channel := make(types.ObjectChannel)
+
+				mock_search_records_by_name(zoneName, "www")
+				err := a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, Name: "www"}, api.ObjectChannel(&channel))
+				Expect(err).NotTo(HaveOccurred())
+				mock_expect_request_count(1)
+
+				r := clouddnsv1.Record{}
+				recordCount := 0
+				for res := range channel {
+					err := res(&r)
+					recordCount += 1
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(r.Name).To(Equal("www"))
+				}
+				Expect(recordCount).To(Equal(2))
+
+				mock_search_records_by_rdata(zoneName, "::1")
+				channel = make(types.ObjectChannel)
+				err = a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, RData: "::1"}, api.ObjectChannel(&channel))
+				Expect(err).NotTo(HaveOccurred())
+				mock_expect_request_count(1)
+
+				recordCount = 0
+				for res := range channel {
+					err := res(&r)
+					recordCount += 1
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(r.RData).To(Equal("::1"))
+				}
+				Expect(recordCount).To(Equal(2))
+
+				mock_search_records_by_type(zoneName, "TXT")
+				channel = make(types.ObjectChannel)
+				err = a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, Type: "TXT"}, api.ObjectChannel(&channel))
+				Expect(err).NotTo(HaveOccurred())
+				mock_expect_request_count(1)
+
+				recordCount = 0
+				for res := range channel {
+					err := res(&r)
+					recordCount += 1
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(r.Type).To(Equal("TXT"))
+				}
+				Expect(recordCount).To(Equal(3))
+
+				mock_search_records_by_all(zoneName, "www", "127.0.0.1", "A")
+				channel = make(types.ObjectChannel)
+				err = a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, Name: "www", RData: "127.0.0.1", Type: "A"}, api.ObjectChannel(&channel))
+				Expect(err).NotTo(HaveOccurred())
+				mock_expect_request_count(1)
+
+				recordCount = 0
+				for res := range channel {
+					err := res(&r)
+					recordCount += 1
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(r.Name).To(Equal("www"))
+					Expect(r.RData).To(Equal("127.0.0.1"))
+					Expect(r.Type).To(Equal("A"))
+				}
+				Expect(recordCount).To(Equal(1))
+			})
 		})
 
-		It("should make a valid delete record request", func() {
-			mock_delete_record(zoneName, identifier)
+		It("should make a valid delete zone request", func() {
+			mock_delete_zone(zoneName)
 
 			ctx, cancel := context.WithTimeout(context.Background(), client.DefaultRequestTimeout)
 			defer cancel()
-			err := a.Destroy(ctx, &clouddnsv1.Record{Identifier: identifier, ZoneName: zoneName})
+
+			zone := clouddnsv1.Zone{Name: zoneName}
+			err := a.Destroy(ctx, &zone)
+
 			Expect(err).NotTo(HaveOccurred())
 
 			mock_expect_request_count(1)
-		})
-	})
 
-	Context("with some records existing", func() {
-		JustBeforeEach(func() {
-			ensureTestZone(a, zoneName, times)
-
-			_ = ensureTestRecord(a, clouddnsv1.Record{
-				Name:     "test1",
-				ZoneName: zoneName,
-				Type:     "TXT",
-				RData:    "test record",
-				Region:   "default",
-				TTL:      300,
-			})
-
-			_ = ensureTestRecord(a, clouddnsv1.Record{
-				Name:     "@",
-				ZoneName: zoneName,
-				Type:     "A",
-				RData:    "127.0.0.1",
-				Region:   "default",
-				TTL:      300,
-			})
-
-			_ = ensureTestRecord(a, clouddnsv1.Record{
-				Name:     "@",
-				ZoneName: zoneName,
-				Type:     "AAAA",
-				RData:    "::1",
-				Region:   "default",
-				TTL:      300,
-			})
-
-			_ = ensureTestRecord(a, clouddnsv1.Record{
-				Name:     "www",
-				ZoneName: zoneName,
-				Type:     "A",
-				RData:    "127.0.0.1",
-				Region:   "default",
-				TTL:      300,
-			})
-
-			_ = ensureTestRecord(a, clouddnsv1.Record{
-				Name:     "www",
-				ZoneName: zoneName,
-				Type:     "AAAA",
-				RData:    "::1",
-				Region:   "default",
-				TTL:      300,
-			})
-		})
-
-		It("lists all records of the zone", func() {
-			mock_list_records(zoneName)
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
-
-			channel := make(types.ObjectChannel)
-			err := a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName}, api.ObjectChannel(&channel))
-			Expect(err).NotTo(HaveOccurred())
-
-			r := clouddnsv1.Record{}
-			rmap := make(map[string]map[string]clouddnsv1.Record, 3)
-			for res := range channel {
-				err := res(&r)
-				Expect(err).NotTo(HaveOccurred())
-				if _, ok := rmap[r.Name]; !ok {
-					rmap[r.Name] = make(map[string]clouddnsv1.Record, 2)
-				}
-
-				rmap[r.Name][r.Type] = r
-			}
-
-			Expect(rmap).To(HaveKey("@"))
-			Expect(rmap).To(HaveKey("www"))
-			Expect(rmap).To(HaveKey("test1"))
-
-			Expect(rmap["@"]).To(HaveKey("A"))
-			Expect(rmap["@"]).To(HaveKey("AAAA"))
-			Expect(rmap["www"]).To(HaveKey("A"))
-			Expect(rmap["www"]).To(HaveKey("AAAA"))
-			Expect(rmap["test1"]).To(HaveKey("TXT"))
-
-			Expect(rmap["@"]["A"].RData).To(Equal("127.0.0.1"))
-			Expect(rmap["www"]["A"].RData).To(Equal("127.0.0.1"))
-			Expect(rmap["@"]["AAAA"].RData).To(Equal("::1"))
-			Expect(rmap["www"]["AAAA"].RData).To(Equal("::1"))
-
-			Expect(rmap["test1"]["TXT"].RData).To(Equal("\"test record\"")) // I love the engine. Mara @LittleFox94 Grosch
-
-			Expect(rmap["@"]["A"].ZoneName).To(Equal(zoneName))
-			Expect(rmap["www"]["A"].ZoneName).To(Equal(zoneName))
-			Expect(rmap["@"]["AAAA"].ZoneName).To(Equal(zoneName))
-			Expect(rmap["www"]["AAAA"].ZoneName).To(Equal(zoneName))
-
-			Expect(rmap["test1"]["TXT"].ZoneName).To(Equal(zoneName))
-
-			mock_expect_request_count(1)
-		})
-
-		It("searches for and finds specific records in the zone", func() {
-
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
-			channel := make(types.ObjectChannel)
-
-			mock_search_records_by_name(zoneName, "www")
-			err := a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, Name: "www"}, api.ObjectChannel(&channel))
-			Expect(err).NotTo(HaveOccurred())
-
-			r := clouddnsv1.Record{}
-			recordCount := 0
-			for res := range channel {
-				err := res(&r)
-				recordCount += 1
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(r.Name).To(Equal("www"))
-			}
-			Expect(recordCount).To(Equal(2))
-
-			mock_search_records_by_rdata(zoneName, "::1")
-			channel = make(types.ObjectChannel)
-			err = a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, RData: "::1"}, api.ObjectChannel(&channel))
-			Expect(err).NotTo(HaveOccurred())
-
-			recordCount = 0
-			for res := range channel {
-				err := res(&r)
-				recordCount += 1
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(r.RData).To(Equal("::1"))
-			}
-			Expect(recordCount).To(Equal(2))
-
-			mock_search_records_by_type(zoneName, "TXT")
-			channel = make(types.ObjectChannel)
-			err = a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, Type: "TXT"}, api.ObjectChannel(&channel))
-			Expect(err).NotTo(HaveOccurred())
-
-			recordCount = 0
-			for res := range channel {
-				err := res(&r)
-				recordCount += 1
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(r.Type).To(Equal("TXT"))
-			}
-			Expect(recordCount).To(Equal(1))
-
-			mock_search_records_by_all(zoneName, "www", "127.0.0.1", "A")
-			channel = make(types.ObjectChannel)
-			err = a.List(ctx, &clouddnsv1.Record{ZoneName: zoneName, Name: "www", RData: "127.0.0.1", Type: "A"}, api.ObjectChannel(&channel))
-			Expect(err).NotTo(HaveOccurred())
-
-			recordCount = 0
-			for res := range channel {
-				err := res(&r)
-				recordCount += 1
-				Expect(err).NotTo(HaveOccurred())
-
-				Expect(r.Name).To(Equal("www"))
-				Expect(r.RData).To(Equal("127.0.0.1"))
-				Expect(r.Type).To(Equal("A"))
-			}
-			Expect(recordCount).To(Equal(1))
+			zoneName = ""
 		})
 	})
 })

--- a/pkg/apis/lbaas/v1/e2e_test.go
+++ b/pkg/apis/lbaas/v1/e2e_test.go
@@ -241,7 +241,7 @@ var _ = Describe("lbaas/v1 bindings", Ordered, func() {
 	testutil.Seed(GinkgoRandomSeed())
 
 	testrun := LBaaSE2ETestRun{
-		Name: testutil.RandomHostname(),
+		Name: testutil.RandomHostname() + "-genclient",
 
 		// there might come a time where we have to check if a port is already in use
 		// and throw another set of dice.

--- a/pkg/clouddns/zone/main_test.go
+++ b/pkg/clouddns/zone/main_test.go
@@ -39,8 +39,4 @@ func TestCloudDNS(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "CloudDNS tests")
-
-	if err := cleanupZones(getClient()); err != nil {
-		t.Fatal(err)
-	}
 }

--- a/pkg/clouddns/zone/mocks_test.go
+++ b/pkg/clouddns/zone/mocks_test.go
@@ -12,7 +12,8 @@ import (
 var mock *mockserver
 
 type mockserver struct {
-	server *ghttp.Server
+	server              *ghttp.Server
+	numRequestsToIgnore int
 }
 
 func initMockServer() {
@@ -24,7 +25,9 @@ func initMockServer() {
 // nolint:golint,unparam
 func mock_expect_request_count(count int) {
 	if mock != nil {
-		Expect(mock.server.ReceivedRequests()).Should(HaveLen(count))
+		Expect(mock.server.ReceivedRequests()).Should(HaveLen(count + mock.numRequestsToIgnore))
+
+		mock.numRequestsToIgnore += count
 	}
 }
 
@@ -203,7 +206,7 @@ func mock_list_records(zone string) {
 			{Name: "@", Type: "AAAA", RData: "::1"},
 			{Name: "www", Type: "A", RData: "127.0.0.1"},
 			{Name: "www", Type: "AAAA", RData: "::1"},
-			{Name: "test1", Type: "TXT", RData: "\"test record\""},
+			{Name: "test5", Type: "TXT", RData: "\"test record\""},
 		}),
 	))
 }

--- a/pkg/vsphere/vsphere_test.go
+++ b/pkg/vsphere/vsphere_test.go
@@ -3,11 +3,15 @@ package vsphere
 import (
 	"testing"
 
+	testutil "go.anx.io/go-anxcloud/pkg/utils/test"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 func TestSpecRunner(t *testing.T) {
+	testutil.Seed(GinkgoRandomSeed())
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "vsphere tests")
 }


### PR DESCRIPTION
### Description

When changing `RandomHostname` and `TestResourceName` in #227, I only ran the unit tests... of course that change broke quite some integration tests, this PR fixes them.

It's some more rework in the CloudDNS test suites, should run faster now as we don't create a fresh zone for each single test anymore.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
