### PR TITLE
SYSENG-1624: Retry failed resource tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Some examples, more below in the actual changelog (newer entries are more likely
 * (internal) generic client: add hook FilterRequestURLHook (#123, @marioreggiori)
 
 -->
+## Fixed
+* (internal) core/v1: Added retry on conflict(409) engine error while tagging resources (#266, @11tuvork28)
 
 ### Changed
 * go-anxcloud is now tested with Go versions 1.19 and 1.20 and we might start using features only available since 1.19

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -1,0 +1,32 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// Retry helper to ease with retrying tasks using the passed callback function.
+func Retry(ctx context.Context, count int, sleep time.Duration, cb func() (bool, error)) error {
+	var (
+		err       error
+		retryable bool
+	)
+
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			logr.FromContextOrDiscard(ctx).Info(fmt.Sprintf("retry callback in a second, due to an error: %s", err))
+			time.Sleep(sleep)
+		}
+
+		if retryable, err = cb(); err == nil {
+			return nil
+		} else if !retryable {
+			break
+		}
+	}
+
+	return err
+}


### PR DESCRIPTION
### Description

Implements retry resource tagging when error 409 Conflict occurs, it retires 2 more times and if both fail it returns the last error.
Failed attempts are logged.


### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
