### PR TITLE
Upgrade to Go 1.20

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -24,9 +24,9 @@ jobs:
     strategy:
       matrix:
         go:
-        - version: "1.19"
-          name: target
         - version: "1.20"
+          name: target
+        - version: "1.21"
           name: latest
     name: "Linting with ${{ matrix.go.name }} Go"
     steps:
@@ -43,9 +43,9 @@ jobs:
     strategy:
       matrix:
         go:
-        - version: "1.19"
-          name: target
         - version: "1.20"
+          name: target
+        - version: "1.21"
           name: latest
     name: "Code generator with ${{ matrix.go.name }} Go"
     steps:
@@ -63,9 +63,9 @@ jobs:
     strategy:
       matrix:
         go:
-        - version: "1.19"
-          name: target
         - version: "1.20"
+          name: target
+        - version: "1.21"
           name: latest
     name: "Unit tests with ${{ matrix.go.name }} Go"
     steps:
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         go:
-        - version: "1.19"
+        - version: "1.20"
           name: target
     name: "Integration tests with ${{ matrix.go.name }} Go (ok-to-test or trusted)"
     steps:

--- a/.github/workflows/dependency.yml
+++ b/.github/workflows/dependency.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         go:
-        - version: "1.19"
-          name: target
         - version: "1.20"
+          name: target
+        - version: "1.21"
           name: latest
     name: "Dependency check with ${{ matrix.go.name }} Go"
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,9 +25,9 @@ jobs:
     strategy:
       matrix:
         go:
-        - version: "1.19"
-          name: target
         - version: "1.20"
+          name: target
+        - version: "1.21"
           name: latest
     name: "Spell check with ${{ matrix.go.name }} Go"
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 * (internal) generic client: add hook FilterRequestURLHook (#123, @marioreggiori)
 
 -->
+
+* go-anxcloud is now tested with Go versions 1.20 and 1.21 and we might start using features only available since 1.20
+
 ## [0.5.3] - 2023-06-16
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.anx.io/go-anxcloud
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.4

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module go.anx.io/go-anxcloud/tools
 
-go 1.19
+go 1.20
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
### Description

Upgrading to Go 1.20, while also testing with Go 1.21.


### Checklist

* [X] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

Needed for #291

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
