### PR TITLE
Add hooks to mock API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+* generic mock client: introduce pre-create hook (#322, @anx-mschaefer)
+
 ## [0.6.1] - 2023-11-17
 
 ### Added

--- a/pkg/api/mock/hooks.go
+++ b/pkg/api/mock/hooks.go
@@ -1,0 +1,21 @@
+package mock
+
+import (
+	"context"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+type hook func(ctx context.Context, a API, o types.IdentifiedObject)
+
+type hookName string
+
+const (
+	preCreateHook hookName = "pre-create"
+)
+
+func WithPreCreateHook(h hook) APIOption {
+	return func(a *mockAPI) {
+		a.hooks[preCreateHook] = append(a.hooks[preCreateHook], h)
+	}
+}


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Adds "pre-create" hook functionality to the mock API client.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
