### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,6 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-          git-tag-gpgsign: true
+          git_tag_gpgsign: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+## [0.6.4] - 2024-03-15
+
+### Fixed
+* fix renamed inputs for crazy-max/ghaction-import-gpg action in release workflow
+
 ## [0.6.3] - 2024-03-15
 
 ### Changed


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Inputs of crazy-max/ghaction-import-gpg action have been changed to use underscores: https://github.com/crazy-max/ghaction-import-gpg/releases/tag/v4.0.0

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
