### PR TITLE
SYSENG-1357: generic client default options

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -87,8 +87,6 @@ jobs:
         go:
         - version: "1.20"
           name: target
-        - version: "1.21"
-          name: latest
     name: "Integration tests with ${{ matrix.go.name }} Go (trusted)"
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+* `WithRequestOptions` API option to configure default request options (#361, @anx-mschaefer)
+
+### Changed
+* (internal) add "error-return" to request option interfaces (#361, @anx-mschaefer)
+
 ## [0.6.4] - 2024-03-15
 
 ### Fixed

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -74,24 +74,30 @@ var _ = Describe("getResponseType function", func() {
 
 type apiTestAnyopOption string
 
-func (o apiTestAnyopOption) ApplyToGet(opts *types.GetOptions) {
-	_ = opts.Set("api_test_option", o, false)
+func (o apiTestAnyopOption) ApplyToGet(opts *types.GetOptions) error {
+	return opts.Set("api_test_option", o, false)
 }
 
-func (o apiTestAnyopOption) ApplyToList(opts *types.ListOptions) {
-	_ = opts.Set("api_test_option", o, false)
+func (o apiTestAnyopOption) ApplyToList(opts *types.ListOptions) error {
+	return opts.Set("api_test_option", o, false)
 }
 
-func (o apiTestAnyopOption) ApplyToCreate(opts *types.CreateOptions) {
-	_ = opts.Set("api_test_option", o, false)
+func (o apiTestAnyopOption) ApplyToCreate(opts *types.CreateOptions) error {
+	return opts.Set("api_test_option", o, false)
 }
 
-func (o apiTestAnyopOption) ApplyToUpdate(opts *types.UpdateOptions) {
-	_ = opts.Set("api_test_option", o, false)
+func (o apiTestAnyopOption) ApplyToUpdate(opts *types.UpdateOptions) error {
+	return opts.Set("api_test_option", o, false)
 }
 
-func (o apiTestAnyopOption) ApplyToDestroy(opts *types.DestroyOptions) {
-	_ = opts.Set("api_test_option", o, false)
+func (o apiTestAnyopOption) ApplyToDestroy(opts *types.DestroyOptions) error {
+	return opts.Set("api_test_option", o, false)
+}
+
+func errorOption(err error) types.AnyOption {
+	return func(o types.Options) error {
+		return err
+	}
 }
 
 type apiTestObject struct {
@@ -1024,6 +1030,87 @@ var _ = Describe("using an API object", func() {
 
 		err = api.Destroy(ctx, &o, opt)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("consumes the default options for all operations", func() {
+		opt := apiTestAnyopOption("hello world")
+		ctx := context.WithValue(context.TODO(), errAPITest, opt)
+
+		server.AppendHandlers(
+			ghttp.RespondWithJSONEncoded(200, map[string]string{"value": "option-check"}),
+			ghttp.RespondWithJSONEncoded(200, map[string]string{"value": "option-check"}),
+			ghttp.RespondWithJSONEncoded(200, []map[string]string{{"value": "option-check"}}),
+			ghttp.RespondWithJSONEncoded(200, map[string]string{"value": "option-check"}),
+			ghttp.RespondWithJSONEncoded(200, map[string]string{}),
+		)
+
+		api, err := NewAPI(
+			WithLogger(logger),
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+			WithRequestOptions(opt),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := apiTestObject{"option-check"}
+
+		err = api.Create(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.Get(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.List(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.Update(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = api.Destroy(ctx, &o)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns an error when applying configured options return errors", func() {
+		mockErr := errors.New("foo")
+		api, err := NewAPI(
+			WithLogger(logger),
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := apiTestObject{"foo"}
+
+		Expect(api.Create(context.TODO(), &o, errorOption(mockErr))).Error().To(MatchError(mockErr))
+		Expect(api.Get(context.TODO(), &o, errorOption(mockErr))).Error().To(MatchError(mockErr))
+		Expect(api.List(context.TODO(), &o, errorOption(mockErr))).Error().To(MatchError(mockErr))
+		Expect(api.Update(context.TODO(), &o, errorOption(mockErr))).Error().To(MatchError(mockErr))
+		Expect(api.Destroy(context.TODO(), &o, errorOption(mockErr))).Error().To(MatchError(mockErr))
+	})
+
+	It("returns an error when applying configured default options return errors", func() {
+		mockErr := errors.New("foo")
+		api, err := NewAPI(
+			WithLogger(logger),
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+			),
+			WithRequestOptions(errorOption(mockErr)),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := apiTestObject{"foo"}
+
+		Expect(api.Create(context.TODO(), &o)).Error().To(MatchError(mockErr))
+		Expect(api.Get(context.TODO(), &o)).Error().To(MatchError(mockErr))
+		Expect(api.List(context.TODO(), &o)).Error().To(MatchError(mockErr))
+		Expect(api.Update(context.TODO(), &o)).Error().To(MatchError(mockErr))
+		Expect(api.Destroy(context.TODO(), &o)).Error().To(MatchError(mockErr))
 	})
 })
 

--- a/pkg/api/internal/options.go
+++ b/pkg/api/internal/options.go
@@ -17,11 +17,12 @@ type PagedOption struct {
 }
 
 // ApplyToList applies the Paged option to all the ListOptions.
-func (p PagedOption) ApplyToList(o *types.ListOptions) {
+func (p PagedOption) ApplyToList(o *types.ListOptions) error {
 	o.Paged = true
 	o.Page = p.Page
 	o.EntriesPerPage = p.Limit
 	o.PageInfo = p.Info
+	return nil
 }
 
 // ObjectChannelOption configures the List operation to return the objects via the given channel.
@@ -30,8 +31,9 @@ type ObjectChannelOption struct {
 }
 
 // ApplyToList applies the AsObjectChannel option to all the ListOptions.
-func (aoc ObjectChannelOption) ApplyToList(o *types.ListOptions) {
+func (aoc ObjectChannelOption) ApplyToList(o *types.ListOptions) error {
 	o.ObjectChannel = aoc.Channel
+	return nil
 }
 
 // FullObjectsOption configures if the List operation shall make a Get operation for each object before
@@ -39,14 +41,16 @@ func (aoc ObjectChannelOption) ApplyToList(o *types.ListOptions) {
 type FullObjectsOption bool
 
 // ApplyToList applies the FullObjectsOption option to all the ListOptions.
-func (foo FullObjectsOption) ApplyToList(o *types.ListOptions) {
+func (foo FullObjectsOption) ApplyToList(o *types.ListOptions) error {
 	o.FullObjects = bool(foo)
+	return nil
 }
 
 // AutoTagOption configures the Create operation to automatically tag objects after creation
 type AutoTagOption []string
 
 // ApplyToCreate applies the AutoTagOption to the ListOptions
-func (ato AutoTagOption) ApplyToCreate(o *types.CreateOptions) {
+func (ato AutoTagOption) ApplyToCreate(o *types.CreateOptions) error {
 	o.AutoTags = ato
+	return nil
 }

--- a/pkg/api/mock/mock_api_implementation.go
+++ b/pkg/api/mock/mock_api_implementation.go
@@ -102,8 +102,12 @@ func listDataAggregation(o types.Object, data mockDataView) ([]types.Object, err
 
 func listOutput(ctx context.Context, objects []types.Object, opts []types.ListOption) error {
 	options := types.ListOptions{}
+	var err error
 	for _, opt := range opts {
-		opt.ApplyToList(&options)
+		err = errors.Join(err, opt.ApplyToList(&options))
+	}
+	if err != nil {
+		return fmt.Errorf("apply request options: %w", err)
 	}
 
 	var channelPageIterator types.PageInfo
@@ -183,8 +187,12 @@ func (a *mockAPI) Create(ctx context.Context, o types.Object, opts ...types.Crea
 	}
 
 	options := types.CreateOptions{}
+	var err error
 	for _, opt := range opts {
-		opt.ApplyToCreate(&options)
+		err = errors.Join(err, opt.ApplyToCreate(&options))
+	}
+	if err != nil {
+		return fmt.Errorf("apply request options: %w", err)
 	}
 
 	a.mu.Lock()

--- a/pkg/api/object_example_test.go
+++ b/pkg/api/object_example_test.go
@@ -229,3 +229,21 @@ func Example_implementObject() {
 	// Retrieved object with mode 'tcp' named 'hello TCP 1'
 	// Retrieved object with mode 'tcp' named 'hello TCP 2'
 }
+
+func ExampleWithRequestOptions() {
+	api, err := NewAPI(
+		WithRequestOptions(
+			// automatically assign tags to newly created resources
+			AutoTag("foo", "bar"),
+		),
+	)
+
+	if err != nil {
+		panic(fmt.Errorf("Error creating API instance: %v\n", err))
+	}
+
+	// create resource and automatically apply 'foo' & 'bar' tags
+	if err := api.Create(context.TODO(), &ExampleObject{Name: "foo"}); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/api/options.go
+++ b/pkg/api/options.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"context"
+	"fmt"
+
 	"go.anx.io/go-anxcloud/pkg/api/internal"
 	"go.anx.io/go-anxcloud/pkg/api/types"
 )
@@ -33,4 +36,24 @@ func FullObjects(fullObjects bool) ListOption {
 // AutoTag can be used to automatically tag objects after creation
 func AutoTag(tags ...string) CreateOption {
 	return internal.AutoTagOption(tags)
+}
+
+// EnvironmentOption can be used to configure an alternative environment path
+// segment for a given API group
+func EnvironmentOption(apiGroup, envPathSegment string, override bool) types.AnyOption {
+	return func(o types.Options) error {
+		return o.SetEnvironment(fmt.Sprintf("environment/%s", apiGroup), envPathSegment, override)
+	}
+}
+
+// GetEnvironmentPathSegment retrieves the environment path segment of a given API group
+// or the provided defaultValue if no environment override is set
+func GetEnvironmentPathSegment(ctx context.Context, apiGroup, defaultValue string) string {
+	if options, err := types.OptionsFromContext(ctx); err != nil {
+		return defaultValue
+	} else if env, err := options.GetEnvironment(fmt.Sprintf("environment/%s", apiGroup)); err != nil {
+		return defaultValue
+	} else {
+		return env
+	}
 }

--- a/pkg/apis/kubernetes/v1/cluster_genclient.go
+++ b/pkg/apis/kubernetes/v1/cluster_genclient.go
@@ -15,7 +15,7 @@ var ErrManagedPrefixSet = errors.New("managed prefixes cannot be set on create")
 
 // EndpointURL returns the common URL for operations on Cluster resource
 func (c *Cluster) EndpointURL(ctx context.Context) (*url.URL, error) {
-	return endpointURL(ctx, c, "/api/kubernetes/v1/cluster.json")
+	return endpointURL(ctx, c, "cluster")
 }
 
 // explicitlyFalse returns true if the value of the provided

--- a/pkg/apis/kubernetes/v1/common.go
+++ b/pkg/apis/kubernetes/v1/common.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 
 	"go.anx.io/go-anxcloud/pkg/api"
@@ -9,7 +10,7 @@ import (
 	"go.anx.io/go-anxcloud/pkg/utils/object/filter"
 )
 
-func endpointURL(ctx context.Context, o types.Object, apiPath string) (*url.URL, error) {
+func endpointURL(ctx context.Context, o types.Object, resourcePathName string) (*url.URL, error) {
 	op, err := types.OperationFromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -19,8 +20,10 @@ func endpointURL(ctx context.Context, o types.Object, apiPath string) (*url.URL,
 		return nil, api.ErrOperationNotSupported
 	}
 
+	env := api.GetEnvironmentPathSegment(ctx, "kubernetes/v1", "kubernetes")
+
 	// we can ignore the error since the URL is hard-coded known as valid
-	u, _ := url.Parse(apiPath)
+	u, _ := url.Parse(fmt.Sprintf("/api/%s/v1/%s.json", env, resourcePathName))
 
 	if op == types.OperationList {
 		helper, err := filter.NewHelper(o)

--- a/pkg/apis/kubernetes/v1/node_pool_genclient.go
+++ b/pkg/apis/kubernetes/v1/node_pool_genclient.go
@@ -7,7 +7,7 @@ import (
 
 // EndpointURL returns the common URL for operations on NodePool resource
 func (np *NodePool) EndpointURL(ctx context.Context) (*url.URL, error) {
-	return endpointURL(ctx, np, "/api/kubernetes/v1/node_pool.json")
+	return endpointURL(ctx, np, "node_pool")
 }
 
 // FilterAPIRequestBody adds the CommonRequestBody

--- a/pkg/vsphere/integration_test.go
+++ b/pkg/vsphere/integration_test.go
@@ -221,7 +221,7 @@ var _ = Describe("vsphere API client", Ordered, func() {
 	})
 
 	It("eventually retrieves the test VM provisioning being completed", func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 		defer cancel()
 
 		id, err := progress.NewAPI(cli).AwaitCompletion(ctx, provisionID)


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
This PR adds functionality to define default requests options via `WithRequestOptions` when creating a new generic API client.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
