### PR TITLE
SYSENG-1749: vsphere/v1 FindNamedTemplate: fall back to any template …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Changed
+* vsphere/v1.FindNamedTemplate: fall back to any template with matching name if no latest build can be determined (#362, @anx-mschaefer)
+
 ## [0.6.4] - 2024-03-15
 
 ### Fixed

--- a/pkg/apis/vsphere/v1/template_test.go
+++ b/pkg/apis/vsphere/v1/template_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Template API bindings", func() {
 				Expect(err).NotTo(HaveOccurred())
 				templateCount++
 			}
-			Expect(templateCount).To(Equal(10))
+			Expect(templateCount).To(Equal(11))
 		})
 
 		It("can Get templates", func() {
@@ -142,6 +142,7 @@ var _ = Describe("Template API bindings", func() {
 			Entry("latest with specified build", "Flatcar Linux Stable", "b74", "26a47eee-dc9a-4eea-b67a-8fb1baa2fcc0"),
 			Entry("not latest build", "Windows 2022", "b06", "cb16dc94-ec55-4e9a-a1a3-b76a91bbe274"),
 			Entry("with non-standard build id", "Debian 11", "possibly-valid-build-id", "9d863fd9-d0d3-4959-b226-e73192f3e43d"),
+			Entry("fallback with non-standard build id", "Fake OS", "", "f39c2a43-97e3-476b-b52b-c3bec7a5c6a2"),
 		)
 
 		DescribeTable("find named template errors", func(name, build string) {
@@ -167,5 +168,6 @@ func mockedTemplateList() []vspherev1.Template {
 		{Identifier: "c3d4f0a6-978a-49fb-a952-7361bf531e4f", Name: "Debian 9", Build: "b92"},
 		{Identifier: "086c5f99-1be6-46ec-8374-cdc23cedd6a4", Name: "Windows 2022", Build: "b12"},
 		{Identifier: "9d863fd9-d0d3-4959-b226-e73192f3e43d", Name: "Debian 11", Build: "possibly-valid-build-id"},
+		{Identifier: "f39c2a43-97e3-476b-b52b-c3bec7a5c6a2", Name: "Fake OS", Build: "kvm-b42"},
 	}
 }


### PR DESCRIPTION
…with matching name if no latest can be determined

### Description

<!--- Please leave a helpful description of the pull request here. --->
KVM based templates have added prefix in build attribute which results in those templates not being found when searching for the latest build of a given template name. This PR adds a fallback to return any name-matching template if no latest build can be determined.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
