### PR TITLE
SYSENG-1764: Add autoscaling to clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 ### Added
 * `WithRequestOptions` API option to configure default request options (#361, @anx-mschaefer)
+* kubernetes/v1: Add `autoscaling` attribute via `EnableAutoscaling` field (#369, @nachtjasmin)
 
 ### Changed
 * (internal) add "error-return" to request option interfaces (#361, @anx-mschaefer)

--- a/pkg/apis/kubernetes/v1/cluster_types.go
+++ b/pkg/apis/kubernetes/v1/cluster_types.go
@@ -57,4 +57,11 @@ type Cluster struct {
 
 	// Contains a kubeconfig if available
 	KubeConfig *string `json:"kubeconfig,omitempty"`
+
+	// Enable autoscaling for this cluster. You will need to explicitly configure
+	// your node pools for autoscaling, please refer to the provided [Autoscaling documentation]
+	// for details. Defaults to false if unset.
+	//
+	// [Autoscaling documentation]: https://engine.anexia-it.com/docs/en/module/kubernetes/user-guide/autoscaling
+	EnableAutoscaling *bool `json:"autoscaling,omitempty"`
 }


### PR DESCRIPTION
### Description

This PR adds the `autoscaling` property to the Kubernetes cluster object, which is already present in the current Engine release.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
