### PR TITLE
SYSENG-1746: Use logger of underlying client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.out.*
 coverage.html
 
 # Dependency directories (remove the comment below to include it)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Fixed
+* pkg/api: use logger of client if `WithLogger` was not called explicitly (#381, @nachtjasmin)
+
 ## [0.7.1] - 2024-06-06
 
 ### Added

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -316,6 +316,35 @@ var _ = Describe("using an API object", func() {
 		Expect(log.String()).To(ContainSubstring("Hello from apiTestObject!"))
 	})
 
+	It("uses the underlying logger on the client", func(ctx context.Context) {
+		server.SetAllowUnhandledRequests(true)
+
+		log := strings.Builder{}
+
+		logger := funcr.New(
+			func(prefix, args string) {
+				_, _ = log.WriteString(prefix + "\t" + args + "\n")
+			},
+			funcr.Options{
+				Verbosity: 3,
+			})
+
+		api, err := NewAPI(
+			WithClientOptions(
+				client.BaseURL(server.URL()),
+				client.IgnoreMissingToken(),
+				client.Logger(logger),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		o := apiTestObject{"identifier"}
+		err = api.Create(ctx, &o)
+		Expect(err).To(HaveOccurred())
+
+		Expect(log.String()).To(ContainSubstring("Hello from apiTestObject!"))
+	})
+
 	It("handles the Object returning an error on EndpointURL", func() {
 		api, err := NewAPI(
 			WithLogger(logger),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -59,6 +59,10 @@ type client struct {
 	metricReceiver    MetricReceiver
 }
 
+// Logger returns the logger of the given client, if provided.
+// It usually should not be used by external callers and is just there to provide a workaround for our generic API.
+func (c client) Logger() logr.Logger { return c.logger }
+
 type clientOptions struct {
 	client
 	ignoreMissingToken bool


### PR DESCRIPTION
### Description

If `WithLogger` was not called yet, we're now using the underlying logger of the client then.

Closes SYSENG-1746.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
