### PR TITLE
Add missing anxcloud:identifier struct tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Fixed
+
+* apis/common: add missing `anxcloud:"identifier"` tag (#391, @nachtjasmin)
+* apis/clouddns/v1: add missing `anxcloud:"identifier"` tag (#391, @nachtjasmin)
+
 ## [0.7.2] - 2024-06-19
 
 ### Fixed

--- a/pkg/apis/clouddns/v1/xxgenerated_object.go
+++ b/pkg/apis/clouddns/v1/xxgenerated_object.go
@@ -11,6 +11,11 @@ func (o *Record) GetIdentifier(ctx context.Context) (string, error) {
 	return o.Identifier, nil
 }
 
+// GetIdentifier returns the primary identifier of a Revision object
+func (o *Revision) GetIdentifier(ctx context.Context) (string, error) {
+	return o.Identifier, nil
+}
+
 // GetIdentifier returns the primary identifier of a Zone object
 func (o *Zone) GetIdentifier(ctx context.Context) (string, error) {
 	return o.Name, nil

--- a/pkg/apis/clouddns/v1/zone_types.go
+++ b/pkg/apis/clouddns/v1/zone_types.go
@@ -4,7 +4,7 @@ import "time"
 
 type Revision struct {
 	CreatedAt  time.Time `json:"created_at"`
-	Identifier string    `json:"identifier"`
+	Identifier string    `json:"identifier" anxcloud:"identifier"`
 	ModifiedAt time.Time `json:"modified_at"`
 	Records    []Record  `json:"records"`
 	Serial     int       `json:"serial"`

--- a/pkg/apis/common/resource.go
+++ b/pkg/apis/common/resource.go
@@ -6,7 +6,7 @@ import (
 
 // PartialResource represents a linked resource
 type PartialResource struct {
-	Identifier string `json:"identifier,omitempty"`
+	Identifier string `json:"identifier,omitempty" anxcloud:"identifier"`
 	Name       string `json:"name,omitempty"`
 }
 


### PR DESCRIPTION
When working on our ake-controller-manager together with the usage of the go-anxcloud mock module, I've stumbled across this issue for the common.PartialResource.

This error is only occuring because the [makeObjectIdentifiable] function requires the `anxcloud:"identifier"` tag to be set. I haven't touched the code in the function itself, as any panic or error caused by it might break existing callers or usecases I haven't considered.

[makeObjectIdentifiable]: pkg/api/mock/utils.go

### Description

<!--- Please leave a helpful description of the pull request here. --->

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
