### PR TITLE
Add pre-update hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+
+* pkg/api/mock: add pre-update hook (#392, @nachtjasmin)
+
 ## [0.7.2] - 2024-06-19
 
 ### Fixed

--- a/pkg/api/mock/hooks.go
+++ b/pkg/api/mock/hooks.go
@@ -6,16 +6,32 @@ import (
 	"go.anx.io/go-anxcloud/pkg/api/types"
 )
 
-type hook func(ctx context.Context, a API, o types.IdentifiedObject)
+// Hook defines actions that can be performed on a given object.
+// They can run pre-creation or pre-update to mock certain domain-specific behaviour
+// of the Anexia Engine.
+type Hook func(ctx context.Context, a API, o types.IdentifiedObject)
 
 type hookName string
 
 const (
 	preCreateHook hookName = "pre-create"
+	preUpdateHook hookName = "pre-update"
 )
 
-func WithPreCreateHook(h hook) APIOption {
+// WithPreCreateHook adds the given hook function to the API.
+//
+// Pre-create hooks are invoked in the order they were added *immediately* upon invocation of Create.
+func WithPreCreateHook(h Hook) APIOption {
 	return func(a *mockAPI) {
 		a.hooks[preCreateHook] = append(a.hooks[preCreateHook], h)
+	}
+}
+
+// WithPreUpdateHook adds the given hook function to the API.
+//
+// Pre-update hooks are invoked in the order they were added *immediately* upon invocation of Update.
+func WithPreUpdateHook(h Hook) APIOption {
+	return func(a *mockAPI) {
+		a.hooks[preUpdateHook] = append(a.hooks[preUpdateHook], h)
 	}
 }

--- a/pkg/api/mock/mock_api_implementation.go
+++ b/pkg/api/mock/mock_api_implementation.go
@@ -18,7 +18,7 @@ import (
 type mockAPI struct {
 	data  mockDataView
 	mu    sync.Mutex
-	hooks map[hookName][]hook
+	hooks map[hookName][]Hook
 }
 
 type APIOption func(*mockAPI)
@@ -27,7 +27,7 @@ type APIOption func(*mockAPI)
 func NewMockAPI(opts ...APIOption) API {
 	a := &mockAPI{
 		data:  make(map[string]*APIObject),
-		hooks: make(map[hookName][]hook),
+		hooks: make(map[hookName][]Hook),
 	}
 
 	for _, opt := range opts {
@@ -231,6 +231,10 @@ func (a *mockAPI) Create(ctx context.Context, o types.Object, opts ...types.Crea
 
 // Update overwrites a types.Object in MockAPIs local storage
 func (a *mockAPI) Update(ctx context.Context, o types.IdentifiedObject, opts ...types.UpdateOption) error {
+	for _, h := range a.hooks[preUpdateHook] {
+		h(ctx, a, o)
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 

--- a/pkg/api/mock/mock_api_implementation_test.go
+++ b/pkg/api/mock/mock_api_implementation_test.go
@@ -209,6 +209,23 @@ var _ = Describe("Mock API implementation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(a.Existing().Unwrap()[id]).To(Equal(&testObject{Identifier: id, TestFieldA: "some text A", TestFieldB: "some text B"}))
 		})
+
+		It("executes hook", func(ctx context.Context) {
+			a := NewMockAPI(
+				WithPreUpdateHook(func(ctx context.Context, a API, o types.IdentifiedObject) {
+					o.(*testObject).TestFieldB = "updated-in-hook"
+				}),
+			)
+
+			id := a.FakeExisting(&testObject{TestFieldA: "some text A"})
+			err := a.Update(ctx, &testObject{Identifier: id})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(a.Existing().Unwrap()[id]).To(Equal(&testObject{
+				Identifier: id,
+				TestFieldA: "some text A",
+				TestFieldB: "updated-in-hook"},
+			))
+		})
 	})
 
 	Context("Destroy operations", func() {


### PR DESCRIPTION
### Description

This adds a pre-update hook in addition to the pre-create hook.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
