### PR TITLE
add possibility to set bandwidth limit for vms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+
+* vsphere/provisioning/vm: add `BandwidthLimit` option (#408 @ProbstenHias)
+
 ## [0.7.3] -- 2024-08-06
 
 ### Added

--- a/pkg/vsphere/provisioning/vm/definition.go
+++ b/pkg/vsphere/provisioning/vm/definition.go
@@ -104,6 +104,9 @@ type Network struct {
 
 	// Example: [ "identifier1", "identifier2", "10.11.12.13", "1.0.0.1" ]
 	IPs []string `json:"ips,omitempty"`
+
+	// Example: 1000
+	BandwidthLimit int `json:"bandwidth_limit,omitempty"`
 }
 
 // NewDefinition create a VM definition with the mandatory values set.


### PR DESCRIPTION
### Description

According to the api documentation it is possible to set the bandwidth limit. With this change it is possible to do the same with the go client.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### Community Note
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
