### PR TITLE
fix: make status field accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Some examples, more below in the actual changelog (newer entries are more likely
 ### Added
 
 * vsphere/provisioning/vm: add `BandwidthLimit` option (#408 @ProbstenHias)
+* vsphere/provisioning/progress: add `Status` (#410, @drpsychick)
 
 ## [0.7.3] -- 2024-08-06
 

--- a/pkg/vsphere/provisioning/progress/progress.go
+++ b/pkg/vsphere/provisioning/progress/progress.go
@@ -23,7 +23,7 @@ const (
 type Progress struct {
 	// TaskIdentifier is the identifier of the provisioning task.
 	TaskIdentifier string `json:"identifier"`
-	// Queued indicated that the task is waiting to be started-
+	// Queued indicates that the task is waiting to be started.
 	Queued bool `json:"queued"`
 	// Progress is the provisioning progress in percent (queuing not included).
 	Progress int `json:"progress"`
@@ -31,6 +31,8 @@ type Progress struct {
 	VMIdentifier string `json:"vm_identifier"`
 	// Errors encountered while provisioning.
 	Errors []string `json:"errors"`
+	// Status of the task.
+	Status int `json:"status"`
 }
 
 // ErrProgress is raised if a poll request completes but the result contains errors.

--- a/pkg/vsphere/provisioning/progress/progress.go
+++ b/pkg/vsphere/provisioning/progress/progress.go
@@ -17,10 +17,15 @@ const (
 	pathPrefix            = "/api/vsphere/v1/provisioning/progress.json"
 	pollInterval          = 5 * time.Second
 	progressCompleteValue = 100
-	statusFailed          = -1
-	statusSuccess         = 1
-	statusInProgress      = 2
-	statusCancelled       = 3
+
+	// StatusFailed indicates that the progress failed.
+	StatusFailed = -1
+	// StatusSuccess indicates that the progress succeeded.
+	StatusSuccess = 1
+	// StatusInProgress indicates that the progress is still ongoing.
+	StatusInProgress = 2
+	// StatusCancelled indicates that the progress has been cancelled.
+	StatusCancelled = 3
 )
 
 // Progress contains information regarding the provisioning of a VM returned by the API .

--- a/pkg/vsphere/provisioning/progress/progress.go
+++ b/pkg/vsphere/provisioning/progress/progress.go
@@ -19,14 +19,16 @@ const (
 	progressCompleteValue = 100
 
 	// StatusFailed indicates that the progress failed.
-	StatusFailed = -1
+	StatusFailed Status = -1
 	// StatusSuccess indicates that the progress succeeded.
-	StatusSuccess = 1
+	StatusSuccess Status = 1
 	// StatusInProgress indicates that the progress is still ongoing.
-	StatusInProgress = 2
+	StatusInProgress Status = 2
 	// StatusCancelled indicates that the progress has been cancelled.
-	StatusCancelled = 3
+	StatusCancelled Status = 3
 )
+
+type Status int
 
 // Progress contains information regarding the provisioning of a VM returned by the API .
 type Progress struct {
@@ -41,7 +43,7 @@ type Progress struct {
 	// Errors encountered while provisioning.
 	Errors []string `json:"errors"`
 	// Status of the task.
-	Status int `json:"status"`
+	Status Status `json:"status"`
 }
 
 // ErrProgress is raised if a poll request completes but the result contains errors.

--- a/pkg/vsphere/provisioning/progress/progress.go
+++ b/pkg/vsphere/provisioning/progress/progress.go
@@ -17,6 +17,10 @@ const (
 	pathPrefix            = "/api/vsphere/v1/provisioning/progress.json"
 	pollInterval          = 5 * time.Second
 	progressCompleteValue = 100
+	statusFailed          = -1
+	statusSuccess         = 1
+	statusInProgress      = 2
+	statusCancelled       = 3
 )
 
 // Progress contains information regarding the provisioning of a VM returned by the API .

--- a/pkg/vsphere/provisioning/progress/progress_test.go
+++ b/pkg/vsphere/provisioning/progress/progress_test.go
@@ -1,0 +1,109 @@
+//go:build !integration
+// +build !integration
+
+package progress
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+	"go.anx.io/go-anxcloud/pkg/client"
+)
+
+var (
+	mock *ghttp.Server
+)
+
+var _ = Describe("vsphere/provisioning/progress API client", func() {
+	var (
+		cli client.Client
+
+		identifier string
+		result     Progress
+		requestErr error
+	)
+
+	JustBeforeEach(func() {
+		result, requestErr = NewAPI(cli).Get(context.TODO(), identifier)
+	})
+
+	Context("retrieving progress", func() {
+		BeforeEach(func() {
+			mock = ghttp.NewServer()
+			var err error
+			cli, err = client.New(client.BaseURL(mock.URL()), client.IgnoreMissingToken())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("progress has failed", func() {
+			BeforeEach(func() {
+				identifier = "statusFailedTest"
+				prepareGet(identifier, []string{}, statusFailed)
+			})
+
+			It("it returns status failed", func() {
+				Expect(requestErr).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Status).To(Equal(statusFailed))
+			})
+		})
+
+		When("progress has succeeded", func() {
+			BeforeEach(func() {
+				identifier = "statusSuccessTest"
+				prepareGet(identifier, []string{}, statusSuccess)
+			})
+
+			It("it returns status success", func() {
+				Expect(requestErr).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Status).To(Equal(statusSuccess))
+			})
+		})
+
+		When("progress has errors", func() {
+			BeforeEach(func() {
+				identifier = "statusInProgressTest"
+				prepareGet(identifier, []string{"some error"}, statusInProgress)
+			})
+
+			It("it returns an error", func() {
+				Expect(requestErr).To(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Status).To(Equal(statusInProgress))
+				Expect(result.Errors).To(HaveLen(1))
+			})
+		})
+
+		When("progress is cancelled", func() {
+			BeforeEach(func() {
+				identifier = "statusCancelledTest"
+				prepareGet(identifier, []string{}, statusCancelled)
+			})
+
+			It("it returns status cancelled", func() {
+				Expect(requestErr).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result.Status).To(Equal(statusCancelled))
+			})
+		})
+	})
+})
+
+func prepareGet(identifier string, errors []string, status int) {
+	mock.AppendHandlers(ghttp.CombineHandlers(
+		ghttp.VerifyRequest("GET", "/api/vsphere/v1/provisioning/progress.json/"+identifier),
+		ghttp.RespondWithJSONEncoded(http.StatusOK, Progress{
+			TaskIdentifier: identifier,
+			Queued:         false,
+			Progress:       0,
+			VMIdentifier:   "",
+			Errors:         errors,
+			Status:         status,
+		}),
+	))
+
+}

--- a/pkg/vsphere/provisioning/progress/progress_test.go
+++ b/pkg/vsphere/provisioning/progress/progress_test.go
@@ -41,39 +41,39 @@ var _ = Describe("vsphere/provisioning/progress API client", func() {
 		When("progress has failed", func() {
 			BeforeEach(func() {
 				identifier = "statusFailedTest"
-				prepareGet(identifier, []string{}, statusFailed)
+				prepareGet(identifier, []string{}, StatusFailed)
 			})
 
 			It("it returns status failed", func() {
 				Expect(requestErr).NotTo(HaveOccurred())
 				Expect(result).NotTo(BeNil())
-				Expect(result.Status).To(Equal(statusFailed))
+				Expect(result.Status).To(Equal(StatusFailed))
 			})
 		})
 
 		When("progress has succeeded", func() {
 			BeforeEach(func() {
 				identifier = "statusSuccessTest"
-				prepareGet(identifier, []string{}, statusSuccess)
+				prepareGet(identifier, []string{}, StatusSuccess)
 			})
 
 			It("it returns status success", func() {
 				Expect(requestErr).NotTo(HaveOccurred())
 				Expect(result).NotTo(BeNil())
-				Expect(result.Status).To(Equal(statusSuccess))
+				Expect(result.Status).To(Equal(StatusSuccess))
 			})
 		})
 
 		When("progress has errors", func() {
 			BeforeEach(func() {
 				identifier = "statusInProgressTest"
-				prepareGet(identifier, []string{"some error"}, statusInProgress)
+				prepareGet(identifier, []string{"some error"}, StatusInProgress)
 			})
 
 			It("it returns an error", func() {
 				Expect(requestErr).To(HaveOccurred())
 				Expect(result).NotTo(BeNil())
-				Expect(result.Status).To(Equal(statusInProgress))
+				Expect(result.Status).To(Equal(StatusInProgress))
 				Expect(result.Errors).To(HaveLen(1))
 			})
 		})
@@ -81,13 +81,13 @@ var _ = Describe("vsphere/provisioning/progress API client", func() {
 		When("progress is cancelled", func() {
 			BeforeEach(func() {
 				identifier = "statusCancelledTest"
-				prepareGet(identifier, []string{}, statusCancelled)
+				prepareGet(identifier, []string{}, StatusCancelled)
 			})
 
 			It("it returns status cancelled", func() {
 				Expect(requestErr).NotTo(HaveOccurred())
 				Expect(result).NotTo(BeNil())
-				Expect(result.Status).To(Equal(statusCancelled))
+				Expect(result.Status).To(Equal(StatusCancelled))
 			})
 		})
 	})

--- a/pkg/vsphere/provisioning/progress/progress_test.go
+++ b/pkg/vsphere/provisioning/progress/progress_test.go
@@ -46,7 +46,6 @@ var _ = Describe("vsphere/provisioning/progress API client", func() {
 
 			It("it returns status failed", func() {
 				Expect(requestErr).NotTo(HaveOccurred())
-				Expect(result).NotTo(BeNil())
 				Expect(result.Status).To(Equal(StatusFailed))
 			})
 		})
@@ -59,7 +58,6 @@ var _ = Describe("vsphere/provisioning/progress API client", func() {
 
 			It("it returns status success", func() {
 				Expect(requestErr).NotTo(HaveOccurred())
-				Expect(result).NotTo(BeNil())
 				Expect(result.Status).To(Equal(StatusSuccess))
 			})
 		})
@@ -72,7 +70,6 @@ var _ = Describe("vsphere/provisioning/progress API client", func() {
 
 			It("it returns an error", func() {
 				Expect(requestErr).To(HaveOccurred())
-				Expect(result).NotTo(BeNil())
 				Expect(result.Status).To(Equal(StatusInProgress))
 				Expect(result.Errors).To(HaveLen(1))
 			})
@@ -86,14 +83,13 @@ var _ = Describe("vsphere/provisioning/progress API client", func() {
 
 			It("it returns status cancelled", func() {
 				Expect(requestErr).NotTo(HaveOccurred())
-				Expect(result).NotTo(BeNil())
 				Expect(result.Status).To(Equal(StatusCancelled))
 			})
 		})
 	})
 })
 
-func prepareGet(identifier string, errors []string, status int) {
+func prepareGet(identifier string, errors []string, status Status) {
 	mock.AppendHandlers(ghttp.CombineHandlers(
 		ghttp.VerifyRequest("GET", "/api/vsphere/v1/provisioning/progress.json/"+identifier),
 		ghttp.RespondWithJSONEncoded(http.StatusOK, Progress{


### PR DESCRIPTION
### Description

Make the `status` field of provisioning progress accessible.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

