### PR TITLE
fix: progress.Status is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+### Added
+* vsphere/provisioning/progress: fix `Status`, it's a string (#412, @drpsychick)
+
 ## [0.7.4] -- 2024-10-21
 
 ### Added

--- a/pkg/vsphere/provisioning/progress/progress.go
+++ b/pkg/vsphere/provisioning/progress/progress.go
@@ -19,16 +19,16 @@ const (
 	progressCompleteValue = 100
 
 	// StatusFailed indicates that the progress failed.
-	StatusFailed Status = -1
+	StatusFailed Status = "-1"
 	// StatusSuccess indicates that the progress succeeded.
-	StatusSuccess Status = 1
+	StatusSuccess Status = "1"
 	// StatusInProgress indicates that the progress is still ongoing.
-	StatusInProgress Status = 2
+	StatusInProgress Status = "2"
 	// StatusCancelled indicates that the progress has been cancelled.
-	StatusCancelled Status = 3
+	StatusCancelled Status = "3"
 )
 
-type Status int
+type Status string
 
 // Progress contains information regarding the provisioning of a VM returned by the API .
 type Progress struct {

--- a/pkg/vsphere/provisioning/progress/progress_test.go
+++ b/pkg/vsphere/provisioning/progress/progress_test.go
@@ -86,20 +86,29 @@ var _ = Describe("vsphere/provisioning/progress API client", func() {
 				Expect(result.Status).To(Equal(StatusCancelled))
 			})
 		})
+
+		When("API returns an invalid status", func() {
+			BeforeEach(func() {
+				prepareGet(identifier, []string{}, "anything")
+			})
+			It("the status is passed through without error", func() {
+				Expect(requestErr).NotTo(HaveOccurred())
+				Expect(result.Status).To(Equal(Status("anything")))
+			})
+		})
 	})
 })
 
 func prepareGet(identifier string, errors []string, status Status) {
 	mock.AppendHandlers(ghttp.CombineHandlers(
 		ghttp.VerifyRequest("GET", "/api/vsphere/v1/provisioning/progress.json/"+identifier),
-		ghttp.RespondWithJSONEncoded(http.StatusOK, Progress{
-			TaskIdentifier: identifier,
-			Queued:         false,
-			Progress:       0,
-			VMIdentifier:   "",
-			Errors:         errors,
-			Status:         status,
+		ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]interface{}{
+			"identifier":    identifier,
+			"queued":        false,
+			"progress":      0,
+			"vm_identifier": "",
+			"errors":        errors,
+			"status":        status,
 		}),
 	))
-
 }


### PR DESCRIPTION
### Description

A mistake slipped through review and tests: progress.Status returned by the API is a string.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

