### PR TITLE
SYSENG-1806: Add missing `bandwidth_limit` field in `info.Network` stuct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 
+* vsphere/info/network: add missing `bandwidth_limit` field in `info.Network` (#417, @89q12) 
+
 ## [0.7.5] -- 2024-10-22
 
 ### Added

--- a/pkg/vsphere/info/info.go
+++ b/pkg/vsphere/info/info.go
@@ -52,12 +52,13 @@ type DiskInfo struct {
 
 // Network contains meta information of attached NICs to a VM.
 type Network struct {
-	NIC        int      `json:"nic"`
-	ID         int      `json:"id"`
-	VLAN       string   `json:"vlan"`
-	MACAddress string   `json:"mac_address"`
-	IPv4       []string `json:"ips_v4"`
-	IPv6       []string `json:"ips_v6"`
+	NIC            int      `json:"nic"`
+	BandwidthLimit int      `json:"bandwidth_limit"`
+	VLAN           string   `json:"vlan"`
+	ID             int      `json:"id"`
+	IPv4           []string `json:"ips_v4"`
+	IPv6           []string `json:"ips_v6"`
+	MACAddress     string   `json:"mac_address"`
 }
 
 // Get returns additional information to a given VM identifier.


### PR DESCRIPTION
### Description

This was missed in the first PR to add the ability to set `bandwidth_limit` as the info endpoint is required to have this field as well, for the Terraform provider to work.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
