### PR TITLE
ENGSUP-8949: consistently use zone_name instead of zoneName.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 ### Fixed
 
+* CloudDNS now consistently uses `zone_name` during requests, fixing integration tests (#432,  @drpsychick)
 * golang/x/net: update to 0.33.0 due to CVE-2024-45338 (#431, @drpsychick)
 
 ## [0.7.6] -- 2024-11-04

--- a/pkg/apis/clouddns/v1/mocks_test.go
+++ b/pkg/apis/clouddns/v1/mocks_test.go
@@ -141,7 +141,7 @@ func mock_update_zone(z clouddnsv1.Zone) {
 
 	expectedData := struct {
 		clouddnsv1.Zone
-		Name string `json:"zoneName"`
+		Name string `json:"zone_name"`
 	}{
 		Zone: z,
 		Name: z.Name,

--- a/pkg/apis/clouddns/v1/zone_genclient.go
+++ b/pkg/apis/clouddns/v1/zone_genclient.go
@@ -36,11 +36,11 @@ func (z *Zone) FilterAPIRequestBody(ctx context.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The Create and Update endpoints expect the Zone's name to be in the request body under the key "zoneName"
+	// The Create and Update endpoints expect the Zone's name to be in the request body under the key "zone_name"
 	if op == types.OperationCreate || op == types.OperationUpdate {
 		zWithZoneName := struct {
 			Zone
-			ZoneName string `json:"zoneName"`
+			ZoneName string `json:"zone_name"`
 		}{*z, z.Name}
 
 		// `name` does not exist as a field on the Engine API for these requests,

--- a/pkg/clouddns/zone/zone.go
+++ b/pkg/clouddns/zone/zone.go
@@ -55,7 +55,7 @@ type Definition struct {
 
 	// Required - Zone name parameter
 	// Parameter used for create/update/delete etc.
-	ZoneName string `json:"zoneName"`
+	ZoneName string `json:"zone_name"`
 
 	// Required - Is master flag
 	// Flag designating if CloudDNS operates as master or slave.
@@ -116,7 +116,7 @@ type ResourceRecord struct {
 }
 
 type Create struct {
-	Name   string `json:"zoneName"`
+	Name   string `json:"zone_name"`
 	Master bool   `json:"master"`
 }
 


### PR DESCRIPTION
### Description

Consistently use zone_name in Anexia Engine requests, fixes integration test failures.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
