### PR TITLE
Add dedicated RateLimitError for HTTP code 429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Some examples, more below in the actual changelog (newer entries are more likely
 * (internal) generic client: add hook FilterRequestURLHook (#123, @marioreggiori)
 
 -->
-
+### Added
+* api: Add RateLimitError (#438, @nachtjasmin)
 
 ## [0.7.7] -- 2025-01-09
 

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -141,6 +141,17 @@ var _ = Describe("ErrorFromResponse function", func() {
 		})
 	})
 
+	Context("for status code 429", func() {
+		BeforeEach(func() {
+			statusCode = 429
+		})
+
+		It("returns RateLimitError", func() {
+			err := ErrorFromResponse(req, res)
+			Expect(IsRateLimitError(err)).To(BeTrue())
+		})
+	})
+
 	Context("for status code 500", func() {
 		BeforeEach(func() {
 			statusCode = 500


### PR DESCRIPTION
Rate limits got introduced by the Anexia Engine at some point in the second half of 2024. Most of our integrations were not prepared for this, especially CCM is suffering from this.

In order to detect rate limits sent by the Engine, a new RateLimitError was added, together with a timestamp after which the requests should be retried again.

I decided to introduce a complex type with a placeholder value for this timestamp right now. This allows us to build other integrations on top of it and when we later update the timestamp with the correct value of the Retry-After header (ENGSUP-9027), all existing implementations would benefit from that without any further manual changes.

Related: ANXKUBE-1281

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
