### PR TITLE
Add errors.Is handling for HTTPError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,16 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 -->
 ### Added
-* api: Add RateLimitError (#438, @nachtjasmin)
+
 * Replace all occurrences of `vmxnet3` with `virtio` (#444, @nachtjasmin)
 * api: Add search parameter to the prefix api (#456, @kkostial)
+* api: Add errors.Is compatibility for newer errors (#458, @nachtjasmin)
+
+## [0.7.8] -- 2025-02-28
+
+### Added
+
+* api: Add RateLimitError (#438, @nachtjasmin)
 
 ## [0.7.7] -- 2025-01-09
 
@@ -46,7 +53,7 @@ Some examples, more below in the actual changelog (newer entries are more likely
 
 ### Added
 
-* vsphere/info/network: add missing `bandwidth_limit` field in `info.Network` (#417, @89q12) 
+* vsphere/info/network: add missing `bandwidth_limit` field in `info.Network` (#417, @89q12)
 
 ## [0.7.5] -- 2024-10-22
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -139,6 +139,20 @@ func (e HTTPError) Error() string {
 	return e.message
 }
 
+// Is overrides the handling for compatibility with the EngineError.
+func (e HTTPError) Is(other error) bool {
+	switch e.statusCode {
+	case 403:
+		return errors.Is(other, ErrAccessDenied)
+	case 404:
+		return errors.Is(other, ErrNotFound)
+	case 429:
+		return IsRateLimitError(other)
+	default:
+		return false
+	}
+}
+
 // ErrorFromResponse creates a new HTTPError from the given response.
 func ErrorFromResponse(req *http.Request, res *http.Response) error {
 	var specificError error

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -103,6 +103,21 @@ var _ = Describe("HTTPError", func() {
 			Expect(err.Error()).To(Equal("Random message for testing"))
 		})
 	})
+
+	DescribeTable("compatibility with errors.Is", func(statusCode int, expected error) {
+		req := httptest.NewRequest("GET", "/", nil)
+		rec := httptest.NewRecorder()
+		rec.WriteHeader(statusCode)
+
+		msg := "Random message for testing"
+		he := newHTTPError(req, rec.Result(), nil, &msg)
+
+		Expect(he).To(MatchError(expected))
+	},
+		Entry("", 403, ErrAccessDenied),
+		Entry("", 404, ErrNotFound),
+		Entry("", 429, RateLimitError{}),
+	)
 })
 
 var _ = Describe("ErrorFromResponse function", func() {


### PR DESCRIPTION
It does not fix the mentioned issue, but at least our newer client errors are now compatible with the errors.Is method.

Related: SYSENG-1804

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
