### PR TITLE
Fix error type in AutoTag example

### DIFF
--- a/pkg/api/options_example_test.go
+++ b/pkg/api/options_example_test.go
@@ -18,8 +18,8 @@ func ExampleAutoTag() {
 
 	vlan := vlanv1.VLAN{DescriptionCustomer: "mocked VLAN"}
 	if err := a.Create(context.TODO(), &vlan, api.AutoTag("foo", "bar", "baz")); err != nil {
-		taggingErr := &api.ErrTaggingFailed{}
-		if errors.As(err, taggingErr) {
+		var taggingErr *api.ErrTaggingFailed
+		if errors.As(err, &taggingErr) {
 			log.Fatalf("object successfully created but tagging failed: %s", taggingErr.Error())
 		} else {
 			log.Fatalf("unknown error occurred: %s", err)


### PR DESCRIPTION
### Description

The [AutoTag example](https://pkg.go.dev/go.anx.io/go-anxcloud@v0.7.9/pkg/api#example-AutoTag) of the Anexia API contains the lines:

```go
		taggingErr := &api.ErrTaggingFailed{}
		if errors.As(err, taggingErr) {
```

which might be irritating to read, but is equivalent to

```go
		var target api.ErrTaggingFailed
		if errors.As(err, &target) {
			taggingErr := &target
```

and assumes that `api.ErrTaggingFailed` is a value error, which is it not.

The error is only returned from [api/errors.go](https://github.com/anexia-it/go-anxcloud/blob/v0.7.9/pkg/api/errors.go#L205) and tested in [api/e2e_test.go](https://github.com/anexia-it/go-anxcloud/blob/v0.7.9/pkg/api/e2e_test.go#L92-L93).

Since the error is somewhat difficult to mock, the easiest way to see the issue is to replace the line

```go
	if err := a.Create(context.TODO(), &vlan, api.AutoTag("foo", "bar", "baz")); err != nil {
```

with

```go
	if err := error(&api.ErrTaggingFailed{}); err != nil {
```

which results in printing _“unknown error occurred”_ instead of _“tagging failed”_. The wrapped error is nil, but this suffices for our demonstration.
