### PR TITLE
test: make kubernetes cluster update test work in integration mode

### DIFF
--- a/pkg/apis/kubernetes/v1/crud_test.go
+++ b/pkg/apis/kubernetes/v1/crud_test.go
@@ -192,6 +192,29 @@ var _ = Describe("CRUD", Ordered, func() {
 
 		Context("Update operation", Ordered, func() {
 			It("can update existing cluster", func() {
+				const testAllowlist = "10.0.0.0/24"
+
+				if isIntegrationTest {
+					cluster := Cluster{Identifier: clusterIdentifier}
+					err := a.Get(context.TODO(), &cluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					cluster.ApiServerAllowlist = testAllowlist
+
+					err = a.Update(context.TODO(), &cluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					err = gs.AwaitCompletion(context.TODO(), a, &cluster)
+					Expect(err).ToNot(HaveOccurred())
+
+					updated := Cluster{Identifier: clusterIdentifier}
+					err = a.Get(context.TODO(), &updated)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updated.ApiServerAllowlist).To(Equal(testAllowlist))
+
+					return
+				}
+
 				testLocation := corev1.Location{
 					Identifier:  "anx04id",
 					Code:        "004",
@@ -202,21 +225,21 @@ var _ = Describe("CRUD", Ordered, func() {
 					Longitude:   pointer.String("2.2"),
 				}
 
-				clusterIdentifier = "test-identifier"
+				mockedIdentifier := "test-identifier"
 				cluster := Cluster{
-					Identifier: clusterIdentifier,
+					Identifier: mockedIdentifier,
 					Name:       "someClusterName",
 					Location:   testLocation,
 				}
 
 				srv.AppendHandlers(ghttp.CombineHandlers(
-					ghttp.VerifyRequest("PUT", fmt.Sprintf("/api/kubernetes/v1/cluster.json/%s", clusterIdentifier)),
+					ghttp.VerifyRequest("PUT", fmt.Sprintf("/api/kubernetes/v1/cluster.json/%s", mockedIdentifier)),
 					ghttp.VerifyJSONRepresenting(struct {
 						Identifier string `json:"identifier"`
 						Name       string `json:"name"`
 						Location   string `json:"location"`
 					}{
-						Identifier: clusterIdentifier,
+						Identifier: mockedIdentifier,
 						Name:       "someClusterName",
 						Location:   testLocation.Identifier,
 					}),
@@ -342,16 +365,22 @@ var _ = Describe("CRUD", Ordered, func() {
 		})
 
 		Context("Update operation", Ordered, func() {
+			BeforeEach(func() {
+				if isIntegrationTest {
+					Skip("node pool update not integration-tested yet")
+				}
+			})
+
 			It("can update existing node pool", func() {
-				nodePoolIdentifier = "test-identifier"
-				nodePool := NodePool{Identifier: nodePoolIdentifier}
+				mockedIdentifier := "test-identifier"
+				nodePool := NodePool{Identifier: mockedIdentifier}
 
 				srv.AppendHandlers(ghttp.CombineHandlers(
-					ghttp.VerifyRequest("PUT", fmt.Sprintf("/api/kubernetes/v1/node_pool.json/%s", nodePoolIdentifier)),
+					ghttp.VerifyRequest("PUT", fmt.Sprintf("/api/kubernetes/v1/node_pool.json/%s", mockedIdentifier)),
 					ghttp.VerifyJSONRepresenting(struct {
 						Identifier string `json:"identifier"`
 					}{
-						Identifier: nodePoolIdentifier,
+						Identifier: mockedIdentifier,
 					}),
 					ghttp.RespondWithJSONEncoded(http.StatusOK, map[string]any{}),
 				))


### PR DESCRIPTION
### Description

The kubernetes/v1 CRUD suite runs against mock handlers in unit mode and against the real Engine in integration mode (`isIntegrationTest`). The two Update tests broke that pattern:

* they called `srv.AppendHandlers(...)` directly instead of going through the nil-safe mock helpers, so in integration mode (where `srv` is nil) they panic
* they overwrote the shared `clusterIdentifier`/`nodePoolIdentifier` with `"test-identifier"`, breaking the subsequent kubeconfig and deletion steps of an integration run

This means cluster/node pool update currently has no real integration coverage, which fits the (stale?) `// This resource does not support updates` comment on the types, even though the client fully implements Update.

Changes:

* the cluster update test now has a real integration path: `Get` the previously created cluster, set `ApiServerAllowlist`, `Update`, `AwaitCompletion`, then `Get` again and assert the allowlist persisted
* the unit-mode mock path is unchanged, but uses a local identifier instead of clobbering the shared one
* the node pool update test is skipped in integration mode for now (it would have panicked before)

Unit suite passes (56/56 specs), and the package vets clean with `-tags integration`.

Note for maintainers: could you add the `integration_tests` label so CI runs the integration suite? As a fork PR I cannot trigger it myself, and it would be interesting to see whether the Engine actually persists `apiserver_allowlist` on update. If it does, the "does not support updates" doc comments on `Cluster`/`NodePool` are probably worth removing in a follow-up.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md), if user facing change (test-only change, not user facing)

### References

<!--- Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? --->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* If you are interested in working on this issue or have submitted a pull request, please leave a comment
